### PR TITLE
fix: cli codegen for idls generated for rust native

### DIFF
--- a/crates/cli/src/handlers/parse.rs
+++ b/crates/cli/src/handlers/parse.rs
@@ -18,13 +18,13 @@ use std::fs::{self};
 
 pub fn parse(options: ParseOptions) -> Result<()> {
     let (accounts_data, instructions_data, types_data, events_data, program_name) =
-        match legacy_read_idl(&options.idl) {
+        match read_idl(&options.idl) {
             Ok(idl) => {
-                let accounts_data = legacy_process_accounts(&idl);
-                let instructions_data = legacy_process_instructions(&idl);
-                let types_data = legacy_process_types(&idl);
-                let events_data = legacy_process_events(&idl);
-                let program_name = idl.name;
+                let accounts_data = process_accounts(&idl);
+                let instructions_data = process_instructions(&idl);
+                let types_data = process_types(&idl);
+                let events_data = process_events(&idl);
+                let program_name = idl.metadata.name;
 
                 (
                     accounts_data,
@@ -34,13 +34,13 @@ pub fn parse(options: ParseOptions) -> Result<()> {
                     program_name,
                 )
             }
-            Err(_legacy_idl_err) => match read_idl(&options.idl) {
+            Err(_legacy_idl_err) => match legacy_read_idl(&options.idl) {
                 Ok(idl) => {
-                    let accounts_data = process_accounts(&idl);
-                    let instructions_data = process_instructions(&idl);
-                    let types_data = process_types(&idl);
-                    let events_data = process_events(&idl);
-                    let program_name = idl.metadata.name;
+                    let accounts_data = legacy_process_accounts(&idl);
+                    let instructions_data = legacy_process_instructions(&idl);
+                    let types_data = legacy_process_types(&idl);
+                    let events_data = legacy_process_events(&idl);
+                    let program_name = idl.name;
 
                     (
                         accounts_data,

--- a/crates/cli/src/instructions.rs
+++ b/crates/cli/src/instructions.rs
@@ -104,7 +104,6 @@ pub fn process_instructions(idl: &Idl) -> Vec<InstructionData> {
         let mut requires_imports = false;
         let module_name = instruction.name.to_snek_case();
         let struct_name = instruction.name.to_upper_camel_case();
-        println!("{} {:?}", instruction.name, instruction.discriminator);
         let discriminator = compute_instruction_discriminator(&instruction.discriminator);
 
         let mut args = Vec::new();
@@ -149,20 +148,10 @@ fn legacy_compute_instruction_discriminator(
 ) -> String {
     if let Some(discriminant) = option_discriminant {
         let disc = format!("0x{}", hex::encode(discriminant.value.to_be_bytes()));
-        println!("{}", disc);
         return disc;
-        // match discriminant.type_.as_str() {
-        //     "u8" => {
-        //         let disc = format!("0x{}", hex::encode(discriminant.value));
-        //         println!("{}", disc);
-        //         return disc;
-        //     }
-        //     _ => {}
-        // }
     } else {
         let mut hasher = Sha256::new();
         let discriminator_input = format!("global:{}", instruction_name);
-        println!("{}", discriminator_input);
         hasher.update(discriminator_input.as_bytes());
         let hash = hasher.finalize();
         let discriminator_bytes = &hash[..8];

--- a/crates/cli/src/legacy_idl.rs
+++ b/crates/cli/src/legacy_idl.rs
@@ -33,12 +33,21 @@ pub struct LegacyIdlConst {
 #[serde(rename_all = "camelCase")]
 pub struct LegacyIdlInstruction {
     pub name: String,
+    pub discriminant: Option<LegacyIdlInstructionDiscriminant>,
     #[serde(default)]
     pub docs: Option<Vec<String>>,
     #[serde(default)]
     pub accounts: Vec<LegacyIdlInstructionAccount>,
     #[serde(default)]
     pub args: Vec<LegacyIdlInstructionArgField>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LegacyIdlInstructionDiscriminant {
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub value: u8,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
so i wanted to fix mpl-token-metadata decoder, but got lazy and thought of actually fixing the cli that generated wrong discriminators. 

i am not aware of the way idl generation for rust native contracts works, but i think i managed to make the cli work. 

pls review, i tested on the [mpl-token-metadata idl](https://github.com/metaplex-foundation/mpl-token-metadata/blob/main/programs/token-metadata/js/idl/mpl_token_metadata.json) and it seems to work