### PR TITLE
refactor: use conventional from traits for instruction extraction

### DIFF
--- a/crates/core/src/account_deletion.rs
+++ b/crates/core/src/account_deletion.rs
@@ -125,7 +125,6 @@ pub trait AccountDeletionPipes: Send + Sync {
     /// # Returns
     ///
     /// Returns a `CarbonResult<()>`, which is `Ok` on success, or an error if processing fails.
-
     async fn run(
         &mut self,
         account_deletion: AccountDeletion,

--- a/datasources/helius-atlas-ws-datasource/src/lib.rs
+++ b/datasources/helius-atlas-ws-datasource/src/lib.rs
@@ -33,7 +33,7 @@ impl Filters {
         transactions: Option<RpcTransactionsConfig>,
     ) -> CarbonResult<Self> {
         if accounts.is_empty() && transactions.is_none() {
-            return CarbonResult::Err(carbon_core::error::Error::Custom(format!("Error creating Filters for the Helius WebSocket: accounts and transactions can't be both empty")));
+            return CarbonResult::Err(carbon_core::error::Error::Custom("Error creating Filters for the Helius WebSocket: accounts and transactions can't be both empty".to_string()));
         };
 
         Ok(Filters {
@@ -260,7 +260,7 @@ impl Datasource for HeliusWebsocket {
                                             inner_instructions: Some(
                                                 meta_original
                                                     .inner_instructions
-                                                    .unwrap_or_else(|| vec![])
+                                                    .unwrap_or_else(std::vec::Vec::new)
                                                     .iter()
                                                     .map(|inner_instruction_group| InnerInstructions {
                                                         index: inner_instruction_group.index,
@@ -305,11 +305,11 @@ impl Datasource for HeliusWebsocket {
                                                     })
                                                     .collect::<Vec<InnerInstructions>>(),
                                             ),
-                                            log_messages: Some(meta_original.log_messages.unwrap_or_else(|| vec![])),
+                                            log_messages: Some(meta_original.log_messages.unwrap_or_else(std::vec::Vec::new)),
                                             pre_token_balances: Some(
                                                 meta_original
                                                     .pre_token_balances
-                                                    .unwrap_or_else(|| vec![])
+                                                    .unwrap_or_else(std::vec::Vec::new)
                                                     .iter()
                                                     .filter_map(|transaction_token_balance| {
                                                         if let (
@@ -337,7 +337,7 @@ impl Datasource for HeliusWebsocket {
                                             post_token_balances: Some(
                                                 meta_original
                                                     .post_token_balances
-                                                    .unwrap_or_else(|| vec![])
+                                                    .unwrap_or_else(std::vec::Vec::new)
                                                     .iter()
                                                     .filter_map(|transaction_token_balance| {
                                                         if let (
@@ -365,7 +365,7 @@ impl Datasource for HeliusWebsocket {
                                             rewards: Some(
                                                 meta_original
                                                     .rewards
-                                                    .unwrap_or_else(|| vec![])
+                                                    .unwrap_or_else(std::vec::Vec::new)
                                                     .iter()
                                                     .map(|rewards| Reward {
                                                         pubkey: rewards.pubkey.clone(),
@@ -387,12 +387,12 @@ impl Datasource for HeliusWebsocket {
                                                     writable: loaded
                                                         .writable
                                                         .iter()
-                                                        .map(|w| Pubkey::from_str(&w).unwrap_or_default())
+                                                        .map(|w| Pubkey::from_str(w).unwrap_or_default())
                                                         .collect::<Vec<Pubkey>>(),
                                                     readonly: loaded
                                                         .readonly
                                                         .iter()
-                                                        .map(|r| Pubkey::from_str(&r).unwrap_or_default())
+                                                        .map(|r| Pubkey::from_str(r).unwrap_or_default())
                                                         .collect::<Vec<Pubkey>>(),
                                                 }
                                             },
@@ -412,7 +412,7 @@ impl Datasource for HeliusWebsocket {
                                             signature,
                                             transaction: decoded_transaction.clone(),
                                             meta: meta_needed,
-                                            is_vote: config.filter.vote.is_some_and(|is_vote| is_vote == true),
+                                            is_vote: config.filter.vote.is_some_and(|is_vote| is_vote),
                                             slot: tx_event.slot,
                                         });
 

--- a/datasources/rpc-block-subscribe-datasource/src/lib.rs
+++ b/datasources/rpc-block-subscribe-datasource/src/lib.rs
@@ -115,7 +115,7 @@ impl Datasource for RpcBlockSubscribe {
                                             };
 
                                             let update = Update::Transaction(TransactionUpdate {
-                                                signature: decoded_transaction.get_signature().clone(),
+                                                signature: *decoded_transaction.get_signature(),
                                                 transaction: decoded_transaction.clone(),
                                                 meta: meta_needed,
                                                 is_vote: false,

--- a/datasources/rpc-transaction-crawler-datasource/src/lib.rs
+++ b/datasources/rpc-transaction-crawler-datasource/src/lib.rs
@@ -156,11 +156,8 @@ fn signature_fetcher(
     metrics: Arc<MetricsCollection>,
 ) -> JoinHandle<()> {
     let rpc_client = Arc::clone(&rpc_client);
-    let account = account;
-    let batch_limit = batch_limit;
     let filters = filters.clone();
     let signature_sender = signature_sender.clone();
-    let polling_interval = polling_interval;
 
     tokio::spawn(async move {
         let mut last_fetched_signature = filters.before_signature;
@@ -178,7 +175,6 @@ fn signature_fetcher(
                         until: filters.until_signature,
                         limit: Some(batch_limit),
                         commitment: Some(commitment.unwrap_or(CommitmentConfig::confirmed())),
-                        ..Default::default()
                     }
                 ) => {
                     match result {
@@ -265,7 +261,6 @@ fn transaction_fetcher(
                                         commitment.unwrap_or(CommitmentConfig::confirmed()),
                                     ),
                                     max_supported_transaction_version: Some(0),
-                                    ..Default::default()
                                 },
                             )
                             .await
@@ -312,7 +307,6 @@ fn transaction_fetcher(
         tokio::select! {
             _ = cancellation_token.cancelled() => {
                 log::info!("Cancelling RPC Crawler transaction fetcher...");
-                return;
             }
             _ = fetch_stream_task => {}
         }

--- a/datasources/yellowstone-grpc-datasource/src/lib.rs
+++ b/datasources/yellowstone-grpc-datasource/src/lib.rs
@@ -143,7 +143,7 @@ impl Datasource for YellowstoneGrpcGeyserClient {
                                                             account_deletions_tracked.read().await;
                                                         if accounts.contains(&account_pubkey) {
                                                             let account_deletion = AccountDeletion {
-                                                                pubkey: account_pubkey.clone(),
+                                                                pubkey: account_pubkey,
                                                                 slot: account_update.slot,
                                                             };
                                                             if let Err(e) = sender.send(


### PR DESCRIPTION
## Motivation

use of idiomatic way to convert types [C-CONV-TRAITS](https://rust-lang.github.io/api-guidelines/interoperability.html#c-conv-traits) instead of self-crafted ones

- implemented  conventional `TryFrom` trait instead of `extract_transaction_metadata`
- implemented  conventional `From` trait instead of  `nest_instructions`
- removed unnecessary `clone()`s
- removed unnecessary closures