### PR TITLE
feat: optional datasource updates parallel processing (workers)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,9 +1252,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",

--- a/crates/core/src/account.rs
+++ b/crates/core/src/account.rs
@@ -165,7 +165,7 @@ pub struct AccountPipe<T: Send> {
 #[async_trait]
 pub trait AccountPipes: Send + Sync {
     async fn run(
-        &mut self,
+        &self,
         account_with_metadata: (AccountMetadata, solana_sdk::account::Account),
         metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()>;
@@ -174,7 +174,7 @@ pub trait AccountPipes: Send + Sync {
 #[async_trait]
 impl<T: Send> AccountPipes for AccountPipe<T> {
     async fn run(
-        &mut self,
+        &self,
         account_with_metadata: (AccountMetadata, solana_sdk::account::Account),
         metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {

--- a/crates/core/src/account_deletion.rs
+++ b/crates/core/src/account_deletion.rs
@@ -126,7 +126,7 @@ pub trait AccountDeletionPipes: Send + Sync {
     ///
     /// Returns a `CarbonResult<()>`, which is `Ok` on success, or an error if processing fails.
     async fn run(
-        &mut self,
+        &self,
         account_deletion: AccountDeletion,
         metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()>;
@@ -135,7 +135,7 @@ pub trait AccountDeletionPipes: Send + Sync {
 #[async_trait]
 impl AccountDeletionPipes for AccountDeletionPipe {
     async fn run(
-        &mut self,
+        &self,
         account_deletion: AccountDeletion,
         metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {

--- a/crates/core/src/instruction.rs
+++ b/crates/core/src/instruction.rs
@@ -124,7 +124,7 @@ pub struct InstructionPipe<T: Send> {
 #[async_trait]
 pub trait InstructionPipes<'a>: Send + Sync {
     async fn run(
-        &mut self,
+        &self,
         nested_instruction: &NestedInstruction,
         metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()>;
@@ -133,7 +133,7 @@ pub trait InstructionPipes<'a>: Send + Sync {
 #[async_trait]
 impl<T: Send + 'static> InstructionPipes<'_> for InstructionPipe<T> {
     async fn run(
-        &mut self,
+        &self,
         nested_instruction: &NestedInstruction,
         metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {

--- a/crates/core/src/processor.rs
+++ b/crates/core/src/processor.rs
@@ -94,7 +94,7 @@ pub trait Processor {
     type InputType;
 
     async fn process(
-        &mut self,
+        &self,
         data: Self::InputType,
         metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()>;

--- a/crates/core/src/transaction.rs
+++ b/crates/core/src/transaction.rs
@@ -70,10 +70,7 @@ impl TryFrom<crate::datasource::TransactionUpdate> for TransactionMetadata {
     type Error = crate::error::Error;
 
     fn try_from(value: crate::datasource::TransactionUpdate) -> Result<Self, Self::Error> {
-        log::trace!(
-            "try_from(transaction_update: {:?})",
-            value
-        );
+        log::trace!("try_from(transaction_update: {:?})", value);
         let accounts = value.transaction.message.static_account_keys();
 
         Ok(TransactionMetadata {
@@ -231,7 +228,7 @@ pub trait TransactionPipes<'a>: Send + Sync {
     ///
     /// A `CarbonResult<()>` indicating success or failure.
     async fn run(
-        &mut self,
+        &self,
         transaction_metadata: TransactionMetadata,
         instructions: &[NestedInstruction],
         metrics: Arc<MetricsCollection>,
@@ -245,7 +242,7 @@ where
     U: DeserializeOwned + Send + Sync + 'static,
 {
     async fn run(
-        &mut self,
+        &self,
         transaction_metadata: TransactionMetadata,
         instructions: &[NestedInstruction],
         metrics: Arc<MetricsCollection>,

--- a/examples/kamino-alerts/src/main.rs
+++ b/examples/kamino-alerts/src/main.rs
@@ -86,7 +86,7 @@ impl Processor for KaminoLendingInstructionProcessor {
     );
 
     async fn process(
-        &mut self,
+        &self,
         (metadata, instruction, _nested_instructions): Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {
@@ -113,7 +113,7 @@ impl Processor for KaminoLendingAccountProcessor {
     type InputType = (AccountMetadata, DecodedAccount<KaminoLendingAccount>);
 
     async fn process(
-        &mut self,
+        &self,
         data: Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {

--- a/examples/meteora-activities/src/main.rs
+++ b/examples/meteora-activities/src/main.rs
@@ -53,7 +53,7 @@ impl Processor for MeteoraInstructionProcessor {
     );
 
     async fn process(
-        &mut self,
+        &self,
         data: Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {

--- a/examples/pumpfun-alerts/src/main.rs
+++ b/examples/pumpfun-alerts/src/main.rs
@@ -63,7 +63,7 @@ impl Processor for PumpfunInstructionProcessor {
     type InputType = InstructionProcessorInputType<PumpfunInstruction>;
 
     async fn process(
-        &mut self,
+        &self,
         data: Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {

--- a/examples/raydium-alerts/src/main.rs
+++ b/examples/raydium-alerts/src/main.rs
@@ -86,7 +86,7 @@ impl Processor for RaydiumAmmV4InstructionProcessor {
     );
 
     async fn process(
-        &mut self,
+        &self,
         (metadata, instruction, _nested_instructions): Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {
@@ -101,16 +101,10 @@ impl Processor for RaydiumAmmV4InstructionProcessor {
                 );
             }
             RaydiumAmmV4Instruction::SwapBaseIn(swap) => {
-                println!(
-                    "\nsignature: {:#?}\nSwap: {:#?}",
-                    signature, swap
-                );
+                println!("\nsignature: {:#?}\nSwap: {:#?}", signature, swap);
             }
             RaydiumAmmV4Instruction::SwapBaseOut(swap) => {
-                println!(
-                    "\nsignature: {:#?}\nSwap: {:#?}",
-                    signature, swap
-                );
+                println!("\nsignature: {:#?}\nSwap: {:#?}", signature, swap);
             }
             _ => {}
         };
@@ -125,7 +119,7 @@ impl Processor for RaydiumAmmV4AccountProcessor {
     type InputType = (AccountMetadata, DecodedAccount<RaydiumAmmV4Account>);
 
     async fn process(
-        &mut self,
+        &self,
         data: Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {

--- a/examples/raydium-clmm-alerts/src/main.rs
+++ b/examples/raydium-clmm-alerts/src/main.rs
@@ -57,7 +57,7 @@ impl Processor for RaydiumClmmInstructionProcessor {
     );
 
     async fn process(
-        &mut self,
+        &self,
         (metadata, instruction, _nested_instructions): Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {

--- a/examples/sharky-offers/src/main.rs
+++ b/examples/sharky-offers/src/main.rs
@@ -102,7 +102,7 @@ impl Processor for SharkyAccountProcessor {
     type InputType = AccountProcessorInputType<SharkyAccount>;
 
     async fn process(
-        &mut self,
+        &self,
         update: Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {


### PR DESCRIPTION
I remember some people were asking about the parallel processing of datasource updates.

This commit adds parallel workers support for concurrent update processing in the pipeline:
- Introduced `parallel_workers` in `PipelineBuilder` to enable parallel processing.
- Workers handle updates concurrently, improving throughput for high-frequency datasources.
- Falls back to sequential processing if `parallel_workers` is unset or set to `<= 1`.
- Integrated per-worker metrics tracking and graceful shutdown handling.
- small update/optimization: now Processor's `process()` and Pipe's `run()` function accepts `&self` instead of `&mut self`.

Example:
```
Pipeline::builder()
    **.parallel_workers(Some(8))** // Enable 8 parallel workers
    .build()?
    .run()
    .await?;
```

The parallel workers feature improves throughput by processing multiple updates concurrently from receiving an update till processing it with a Processor, but it won't significantly help if a processor contains blocking operations like getting a DB connection from an r2d2 pool in every `process()` call. Such blocking operations can still become bottlenecks, limiting overall parallel efficiency.