### PR TITLE
feat: codama idls parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ $ carbon-cli parse [OPTIONS] --idl <IDL> --output <OUTPUT>
 $ carbon-cli parse --idl my_program.json --output ./src/decoders
 ```
 
-This will parse the my_program.json IDL file and generate the corresponding decoder code in the ./src/decoders directory.
+1. This will parse the my_program.json IDL file and generate the corresponding decoder code in the ./src/decoders directory.
 
 - To generate a decoder from an Anchor PDA IDL, specify a program address (Meteora DLMM program in this case):
 
@@ -135,7 +135,7 @@ This will parse the my_program.json IDL file and generate the corresponding deco
 $ carbon-cli parse --idl LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo -u mainnet-beta --output ./src/decoders
 ```
 
-This will fetch Meteora DLMM program's IDL from chain and generate the corresponding decoder code in the ./src/decoders directory.
+2. This will fetch Meteora DLMM program's IDL from chain and generate the corresponding decoder code in the ./src/decoders directory.
 
 - To generate a decoder from a Codama IDL:
 
@@ -143,7 +143,7 @@ This will fetch Meteora DLMM program's IDL from chain and generate the correspon
 $ carbon-cli parse --idl my_program_codama.json --output ./src/decoders --codama
 ```
 
-This will parse the my_program_codama.json Codama IDL file and generate the corresponding decoder code in the ./src/decoders directory.
+3. This will parse the my_program_codama.json Codama IDL file and generate the corresponding decoder code in the ./src/decoders directory.
 
 **Note**: in order to parse CPI Events for a provided Codama IDL, add `--event-hints` option with comma-separated names of corresponding defined Codama types:
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 Decoders implementations allow the pipeline to input raw account or instruction data and to receive deserialized account or instruction data. They are the backbone of indexing with Carbon.
 
-Carbon provides a CLI tool to generate decoders based on IDL files. This can significantly speed up the process of creating custom decoders for your Solana programs.
+Carbon provides a CLI tool to generate decoders based on IDL files (Anchor, Codama) or from a provided program address with a network specified to fetch an on-chain PDA IDL. This can significantly speed up the process of creating custom decoders for your Solana programs.
 
 #### CLI Installation
 
@@ -111,20 +111,45 @@ $ carbon-cli parse [OPTIONS] --idl <IDL> --output <OUTPUT>
 
 #### Options
 
-- `-i, --idl <IDL>`: Path to the IDL json file.
+- `-i, --idl <IDL>`: Path to an IDL json file or a Solana program address.
 - `-o, --output <OUTPUT>`: Path to the desired output directory.
 - `-C, --as-crate`: Generate a directory or a crate.
+- `--codama`: The IDL json file to parse is a Codama IDL.
+- `-e, --event-hints`: Comma-separated names of defined types to parse as CPI Events (for '--codama' option only).
+- `-u, --url`: Network URL to fetch the IDL from. Required if input is a program address.
 - `-h, --help`: Print help information.
 
-#### Example
+#### Examples
 
-To generate a decoder from an IDL file:
+- To generate a decoder from an IDL file:
 
 ```sh
 $ carbon-cli parse --idl my_program.json --output ./src/decoders
 ```
 
 This will parse the my_program.json IDL file and generate the corresponding decoder code in the ./src/decoders directory.
+
+- To generate a decoder from an Anchor PDA IDL, specify a program address (Meteora DLMM program in this case):
+
+```sh
+$ carbon-cli parse --idl LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo -u mainnet-beta --output ./src/decoders
+```
+
+This will fetch Meteora DLMM program's IDL from chain and generate the corresponding decoder code in the ./src/decoders directory.
+
+- To generate a decoder from a Codama IDL:
+
+```sh
+$ carbon-cli parse --idl my_program_codama.json --output ./src/decoders --codama
+```
+
+This will parse the my_program_codama.json Codama IDL file and generate the corresponding decoder code in the ./src/decoders directory.
+
+**Note**: in order to parse CPI Events for a provided Codama IDL, add `--event-hints` option with comma-separated names of corresponding defined Codama types:
+
+```sh
+$ carbon-cli parse --idl my_program_codama.json --output ./src/decoders --codama --event-hints event1,event2,event3
+```
 
 ### Implementing Processors
 

--- a/README.md
+++ b/README.md
@@ -121,29 +121,29 @@ $ carbon-cli parse [OPTIONS] --idl <IDL> --output <OUTPUT>
 
 #### Examples
 
-- To generate a decoder from an IDL file:
+1. To generate a decoder from an IDL file:
 
 ```sh
 $ carbon-cli parse --idl my_program.json --output ./src/decoders
 ```
 
-1. This will parse the my_program.json IDL file and generate the corresponding decoder code in the ./src/decoders directory.
+This will parse the my_program.json IDL file and generate the corresponding decoder code in the ./src/decoders directory.
 
-- To generate a decoder from an Anchor PDA IDL, specify a program address (Meteora DLMM program in this case):
+2. To generate a decoder from an Anchor PDA IDL, specify a program address (Meteora DLMM program in this case):
 
 ```sh
 $ carbon-cli parse --idl LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo -u mainnet-beta --output ./src/decoders
 ```
 
-2. This will fetch Meteora DLMM program's IDL from chain and generate the corresponding decoder code in the ./src/decoders directory.
+This will fetch Meteora DLMM program's IDL from chain and generate the corresponding decoder code in the ./src/decoders directory.
 
-- To generate a decoder from a Codama IDL:
+3. To generate a decoder from a Codama IDL:
 
 ```sh
 $ carbon-cli parse --idl my_program_codama.json --output ./src/decoders --codama
 ```
 
-3. This will parse the my_program_codama.json Codama IDL file and generate the corresponding decoder code in the ./src/decoders directory.
+This will parse the my_program_codama.json Codama IDL file and generate the corresponding decoder code in the ./src/decoders directory.
 
 **Note**: in order to parse CPI Events for a provided Codama IDL, add `--event-hints` option with comma-separated names of corresponding defined Codama types:
 

--- a/README.md
+++ b/README.md
@@ -113,21 +113,21 @@ $ carbon-cli parse [OPTIONS] --idl <IDL> --output <OUTPUT>
 
 - `-i, --idl <IDL>`: Path to an IDL json file or a Solana program address.
 - `-o, --output <OUTPUT>`: Path to the desired output directory.
-- `-C, --as-crate`: Generate a directory or a crate.
-- `--codama`: The IDL json file to parse is a Codama IDL.
-- `-e, --event-hints`: Comma-separated names of defined types to parse as CPI Events (for '--codama' option only).
+- `-c, --as-crate`: Generate a directory or a crate.
+- `-s, --standard`: Specify the IDL standard to parse. Default: 'anchor' if not specified..
+- `-e, --event-hints`: Comma-separated names of defined types to parse as CPI Events (for '--standard codama' option only).
 - `-u, --url`: Network URL to fetch the IDL from. Required if input is a program address.
 - `-h, --help`: Print help information.
 
 #### Examples
 
-1. To generate a decoder from an IDL file:
+1. To generate a decoder from an Anchor IDL file:
 
 ```sh
 $ carbon-cli parse --idl my_program.json --output ./src/decoders
 ```
 
-This will parse the my_program.json IDL file and generate the corresponding decoder code in the ./src/decoders directory.
+This will parse the my_program.json Anchor IDL file and generate the corresponding decoder code in the ./src/decoders directory.
 
 2. To generate a decoder from an Anchor PDA IDL, specify a program address (Meteora DLMM program in this case):
 
@@ -140,7 +140,7 @@ This will fetch Meteora DLMM program's IDL from chain and generate the correspon
 3. To generate a decoder from a Codama IDL:
 
 ```sh
-$ carbon-cli parse --idl my_program_codama.json --output ./src/decoders --codama
+$ carbon-cli parse --idl my_program_codama.json --output ./src/decoders --standard codama
 ```
 
 This will parse the my_program_codama.json Codama IDL file and generate the corresponding decoder code in the ./src/decoders directory.
@@ -148,7 +148,7 @@ This will parse the my_program_codama.json Codama IDL file and generate the corr
 **Note**: in order to parse CPI Events for a provided Codama IDL, add `--event-hints` option with comma-separated names of corresponding defined Codama types:
 
 ```sh
-$ carbon-cli parse --idl my_program_codama.json --output ./src/decoders --codama --event-hints event1,event2,event3
+$ carbon-cli parse --idl my_program_codama.json --output ./src/decoders --standard codama --event-hints event1,event2,event3
 ```
 
 ### Implementing Processors

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -29,9 +29,13 @@ pub struct ParseOptions {
     #[arg(help = "Path to the desired output directory.")]
     pub output: String,
 
-    #[arg(short = 'C', long = "as-crate", default_value_t = false)]
+    #[arg(short = 'c', long = "as-crate", default_value_t = false)]
     #[arg(help = "Generate a directory or a crate.")]
     pub as_crate: bool,
+
+    #[arg(long = "codama", default_value_t = false)]
+    #[arg(help = "The IDL json file to parse is a Codama IDL.")]
+    pub codama: bool,
 
     #[arg(short, long, required_if_eq("idl", "ProgramAddress"))]
     #[arg(help = "Network URL to fetch the IDL from. Required if input is a program address.")]

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -1,6 +1,5 @@
+use clap::{Parser, Subcommand, ValueEnum};
 use std::str::FromStr;
-
-use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
 #[command(name = "IDL Parser CLI")]
@@ -33,9 +32,9 @@ pub struct ParseOptions {
     #[arg(help = "Generate a directory or a crate.")]
     pub as_crate: bool,
 
-    #[arg(long = "codama", default_value_t = false)]
-    #[arg(help = "The IDL json file to parse is a Codama IDL.")]
-    pub codama: bool,
+    #[arg(short, long = "standard", default_value = "anchor")]
+    #[arg(help = "Specify the IDL standard to parse.")]
+    pub standard: IdlStandard,
 
     #[arg(short, long)]
     #[arg(help = "Comma-separated names of defined types to parse as CPI Events.")]
@@ -84,6 +83,24 @@ impl FromStr for Url {
             _ => {
                 Err("Invalid network: Must be 'mainnet', 'devnet', or a valid RPC URL.".to_string())
             }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum IdlStandard {
+    Anchor,
+    Codama,
+}
+
+impl std::str::FromStr for IdlStandard {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "anchor" => Ok(IdlStandard::Anchor),
+            "codama" => Ok(IdlStandard::Codama),
+            _ => Err("Invalid Idl Standard: Must be 'anchor' or 'codama'.".to_string()),
         }
     }
 }

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -37,6 +37,10 @@ pub struct ParseOptions {
     #[arg(help = "The IDL json file to parse is a Codama IDL.")]
     pub codama: bool,
 
+    #[arg(short, long)]
+    #[arg(help = "Comma-separated names of defined types to parse as CPI Events.")]
+    pub event_hints: Option<String>,
+
     #[arg(short, long, required_if_eq("idl", "ProgramAddress"))]
     #[arg(help = "Network URL to fetch the IDL from. Required if input is a program address.")]
     pub url: Option<Url>,

--- a/crates/cli/src/handlers/codama/mod.rs
+++ b/crates/cli/src/handlers/codama/mod.rs
@@ -1,0 +1,6 @@
+mod parse_codama;
+mod processors;
+mod types;
+mod utils;
+
+pub use parse_codama::*;

--- a/crates/cli/src/handlers/codama/parse_codama.rs
+++ b/crates/cli/src/handlers/codama/parse_codama.rs
@@ -1,0 +1,219 @@
+use crate::{
+    accounts::{
+        legacy_process_accounts, process_accounts, AccountsModTemplate, AccountsStructTemplate,
+    },
+    events::{legacy_process_events, process_events, EventsStructTemplate},
+    instructions::{
+        legacy_process_instructions, process_instructions, InstructionsModTemplate,
+        InstructionsStructTemplate,
+    },
+    types::{legacy_process_types, process_types, TypeStructTemplate},
+    util::{is_big_array, legacy_read_idl, read_idl},
+};
+use anyhow::{bail, Result};
+use askama::Template;
+use heck::{ToKebabCase, ToSnakeCase, ToSnekCase, ToUpperCamelCase};
+use std::fs::{self};
+
+pub fn parse_codama(path: String, output: String, as_crate: bool) -> Result<()> {
+    // TODO: read codama idl
+    let (accounts_data, instructions_data, types_data, events_data, program_name) =
+        match read_idl(&path) {
+            Ok(idl) => {
+                let accounts_data = process_accounts(&idl);
+                let instructions_data = process_instructions(&idl);
+                let types_data = process_types(&idl);
+                let events_data = process_events(&idl);
+                let program_name = idl.metadata.name;
+
+                (
+                    accounts_data,
+                    instructions_data,
+                    types_data,
+                    events_data,
+                    program_name,
+                )
+            }
+            Err(error) => {
+                bail!("Error parsing Codama IDL: {error}");
+            }
+        };
+
+    let decoder_name = format!("{}Decoder", program_name.to_upper_camel_case());
+    let decoder_name_kebab = program_name.to_kebab_case();
+    let program_struct_name = format!("{}Account", program_name.to_upper_camel_case());
+    let program_instruction_enum = format!("{}Instruction", program_name.to_upper_camel_case());
+
+    let crate_dir = if output.ends_with("/") {
+        if as_crate {
+            format!("{}{}-decoder", output, decoder_name_kebab)
+        } else {
+            format!("{}{}_decoder", output, program_name.to_snek_case())
+        }
+    } else {
+        if as_crate {
+            format!("{}/{}-decoder", output, decoder_name_kebab)
+        } else {
+            format!("{}/{}_decoder", output, program_name.to_snek_case())
+        }
+    };
+
+    fs::create_dir_all(&crate_dir).expect("Failed to create decoder directory");
+
+    let src_dir = if as_crate {
+        format!("{}/src", crate_dir)
+    } else {
+        crate_dir.clone()
+    };
+
+    fs::create_dir_all(&src_dir).expect("Failed to create src directory");
+
+    let needs_big_array = types_data.iter().any(|type_data| {
+        type_data.fields.iter().any(|field| {
+            field.rust_type.starts_with("[")
+                && field.rust_type.ends_with("]")
+                && is_big_array(&field.rust_type)
+        })
+    });
+
+    // Generate types
+    let types_dir = format!("{}/types", src_dir);
+    fs::create_dir_all(&types_dir).expect("Failed to create types directory");
+
+    for type_data in &types_data {
+        let template = TypeStructTemplate { type_data };
+        let rendered = template.render().unwrap();
+        let filename = format!("{}/{}.rs", types_dir, type_data.name.to_snake_case());
+        fs::write(&filename, rendered).expect("Failed to write type struct file");
+        println!("Generated {}", filename);
+    }
+
+    let mut types_mod_content = types_data
+        .iter()
+        .map(|type_data| {
+            format!(
+                "pub mod {};\npub use {}::*;",
+                type_data.name.to_snake_case(),
+                type_data.name.to_snake_case()
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    if needs_big_array {
+        types_mod_content.push_str("\nuse serde_big_array::BigArray;\n");
+    }
+
+    let types_mod_filename = format!("{}/mod.rs", types_dir);
+    fs::write(&types_mod_filename, types_mod_content).expect("Failed to write types mod file");
+    println!("Generated {}", types_mod_filename);
+
+    // Generate Accounts
+
+    let accounts_dir = format!("{}/accounts", src_dir);
+    fs::create_dir_all(&accounts_dir).expect("Failed to create accounts directory");
+
+    for account in &accounts_data {
+        let template = AccountsStructTemplate { account };
+        let rendered = template.render().unwrap();
+        let filename = format!("{}/{}.rs", accounts_dir, account.module_name);
+        fs::write(&filename, rendered).expect("Failed to write account struct file");
+        println!("Generated {}", filename);
+    }
+
+    let accounts_mod_template = AccountsModTemplate {
+        accounts: &accounts_data,
+        decoder_name: decoder_name.clone(),
+        program_struct_name: program_struct_name.clone(),
+    };
+    let accounts_mod_rendered = accounts_mod_template.render().unwrap();
+    let accounts_mod_filename = format!("{}/mod.rs", accounts_dir);
+
+    fs::write(&accounts_mod_filename, accounts_mod_rendered)
+        .expect("Failed to write accounts mod file");
+    println!("Generated {}", accounts_mod_filename);
+
+    // Generate Instructions
+
+    let instructions_dir = format!("{}/instructions", src_dir);
+    fs::create_dir_all(&instructions_dir).expect("Failed to create instructions directory");
+
+    for instruction in &instructions_data {
+        let template = InstructionsStructTemplate { instruction };
+        let rendered = template.render().unwrap();
+        let filename = format!("{}/{}.rs", instructions_dir, instruction.module_name);
+        fs::write(&filename, rendered).expect("Failed to write instruction struct file");
+        println!("Generated {}", filename);
+    }
+
+    for event in &events_data {
+        let template = EventsStructTemplate { event };
+        let rendered = template.render().unwrap();
+        let filename = format!("{}/{}.rs", instructions_dir, event.module_name);
+        fs::write(&filename, rendered).expect("Failed to write event struct file");
+        println!("Generated {}", filename);
+    }
+
+    let instructions_mod_template = InstructionsModTemplate {
+        instructions: &instructions_data,
+        decoder_name: decoder_name.clone(),
+        program_instruction_enum: program_instruction_enum.clone(),
+        events: &events_data,
+    };
+    let instructions_mod_rendered = instructions_mod_template.render().unwrap();
+    let instructions_mod_filename = format!("{}/mod.rs", instructions_dir);
+
+    fs::write(&instructions_mod_filename, instructions_mod_rendered)
+        .expect("Failed to write instructions mod file");
+
+    println!("Generated {}", instructions_mod_filename);
+
+    if as_crate {
+        let lib_rs_content = format!(
+            "pub struct {decoder_name};\npub mod accounts;\npub mod instructions;\npub mod types;",
+            decoder_name = decoder_name
+        );
+        let lib_rs_filename = format!("{}/lib.rs", src_dir);
+        fs::write(&lib_rs_filename, lib_rs_content).expect("Failed to write lib.rs file");
+        println!("Generated {}", lib_rs_filename);
+
+        let cargo_toml_content = format!(
+            r#"[package]
+name = "{decoder_name_kebab}-decoder"
+version = "0.1.4"
+edition = "2018"
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+carbon-core = {{ workspace = true }}
+carbon-proc-macros = {{ workspace = true }}
+carbon-macros = {{ workspace = true }}
+solana-sdk = "2.0.10"
+serde = "1.0.136"
+{big_array}
+"#,
+            decoder_name_kebab = decoder_name_kebab,
+            big_array = if needs_big_array {
+                "serde-big-array = \"0.5.1\""
+            } else {
+                ""
+            }
+        );
+        let cargo_toml_filename = format!("{}/Cargo.toml", crate_dir);
+        fs::write(&cargo_toml_filename, cargo_toml_content)
+            .expect("Failed to write Cargo.toml file");
+        println!("Generated {}", cargo_toml_filename);
+    } else {
+        let mod_rs_content = format!(
+            "pub struct {decoder_name};\npub mod accounts;\npub mod instructions;\npub mod types;",
+            decoder_name = decoder_name
+        );
+        let mod_rs_filename = format!("{}/mod.rs", src_dir);
+        fs::write(&mod_rs_filename, mod_rs_content).expect("Failed to write mod.rs file");
+        println!("Generated {}", mod_rs_filename);
+    }
+
+    Ok(())
+}

--- a/crates/cli/src/handlers/codama/processors.rs
+++ b/crates/cli/src/handlers/codama/processors.rs
@@ -1,11 +1,17 @@
 use super::{
-    types::{
-        AccountData, AccountMetaData, ArgumentData, EnumVariantData, EnumVariantFields,
-        EnumVariantTypeNode, FieldData, InstructionData, ProgramNode, TypeData, TypeKind, TypeNode,
+    types::{EnumVariantTypeNode, ProgramNode, SignerType, TypeNode},
+    utils::{
+        get_account_discriminator, get_event_discriminator, get_instruction_discriminator, map_type,
     },
-    utils::{get_instruction_discriminator, map_type},
+};
+use crate::{
+    accounts::{AccountData, FieldData as AccountFieldData},
+    events::EventData,
+    instructions::{AccountMetaData, ArgumentData, InstructionData},
+    types::{EnumVariantData, EnumVariantFields, FieldData, TypeData, TypeKind},
 };
 use heck::{ToSnekCase, ToUpperCamelCase};
+use std::collections::HashSet;
 
 pub fn process_codama_accounts(program: &ProgramNode) -> Vec<AccountData> {
     let mut accounts_data = Vec::new();
@@ -15,21 +21,21 @@ pub fn process_codama_accounts(program: &ProgramNode) -> Vec<AccountData> {
 
         let struct_name = account.name.to_upper_camel_case();
         let module_name = account.name.to_snek_case();
-        let discriminator = "".to_string(); // TODO: get discriminator as from ixs
+        let discriminator = get_account_discriminator(account, &account.name);
 
         let mut fields = Vec::new();
         for field in &account.data.fields {
+            if field.name == "discriminator" {
+                continue;
+            }
             let rust_type = map_type(&field.field_type);
-            if rust_type.contains("Pubkey") {
+            if rust_type.1 {
                 requires_imports = true;
             }
 
-            let is_pubkey = rust_type == "Pubkey";
-            fields.push(FieldData {
+            fields.push(AccountFieldData {
                 name: field.name.to_snek_case(),
-                rust_type,
-                is_pubkey,
-                attributes: None,
+                rust_type: rust_type.0,
             });
         }
 
@@ -58,13 +64,16 @@ pub fn process_codama_instructions(program: &ProgramNode) -> Vec<InstructionData
 
         let mut args = Vec::new();
         for arg in &instruction.arguments {
+            if arg.name == "discriminator" {
+                continue;
+            }
             let rust_type = map_type(&arg.arg_type);
-            if rust_type.contains("Pubkey") {
+            if rust_type.1 {
                 requires_imports = true;
             }
             args.push(ArgumentData {
                 name: arg.name.to_snek_case(),
-                rust_type,
+                rust_type: rust_type.0,
             });
         }
 
@@ -73,7 +82,11 @@ pub fn process_codama_instructions(program: &ProgramNode) -> Vec<InstructionData
             accounts.push(AccountMetaData {
                 name: account.name.to_snek_case(),
                 is_mut: account.is_writable,
-                is_signer: account.is_signer,
+                is_signer: match account.is_signer {
+                    SignerType::Boolean(is_signer) => is_signer,
+                    SignerType::Either(_) => false,
+                },
+                is_optional: account.is_optional,
             });
         }
 
@@ -90,29 +103,32 @@ pub fn process_codama_instructions(program: &ProgramNode) -> Vec<InstructionData
     instructions_data
 }
 
-pub fn process_codama_defined_types(program: &ProgramNode) -> Vec<TypeData> {
+pub fn process_codama_defined_types(
+    program: &ProgramNode,
+    event_hints: &HashSet<String>,
+) -> (Vec<TypeData>, Vec<EventData>) {
     let mut types_data = Vec::new();
+    let mut events_data = Vec::new();
 
     for defined_type in &program.defined_types {
         let mut requires_imports = false;
-
-        let name = defined_type.name.clone();
+        let name = defined_type.name.to_upper_camel_case().clone();
         let mut fields = Vec::new();
         let mut kind = TypeKind::Struct;
 
-        match &defined_type.data {
+        match &defined_type.type_node {
             TypeNode::StructTypeNode {
                 fields: struct_fields,
             } => {
                 for field in struct_fields {
                     let rust_type = map_type(&field.field_type);
-                    if rust_type.contains("Pubkey") {
+                    if rust_type.1 {
                         requires_imports = true;
                     }
-                    let is_pubkey = rust_type == "Pubkey";
+                    let is_pubkey = rust_type.0 == "Pubkey";
                     fields.push(FieldData {
                         name: field.name.to_snek_case(),
-                        rust_type,
+                        rust_type: rust_type.0,
                         is_pubkey,
                         attributes: None,
                     });
@@ -125,32 +141,49 @@ pub fn process_codama_defined_types(program: &ProgramNode) -> Vec<TypeData> {
                         .map(|variant| match variant {
                             EnumVariantTypeNode::EnumEmptyVariantTypeNode { name } => {
                                 EnumVariantData {
-                                    name: name.clone(),
+                                    name: name.to_upper_camel_case().clone(),
                                     fields: None,
                                 }
                             }
-                            EnumVariantTypeNode::EnumStructVariantTypeNode { name, fields } => {
-                                let named_fields = fields
+                            EnumVariantTypeNode::EnumStructVariantTypeNode {
+                                name,
+                                struct_type,
+                            } => {
+                                let named_fields = struct_type
+                                    .fields
                                     .iter()
                                     .map(|field| {
                                         let rust_type = map_type(&field.field_type);
+                                        if rust_type.1 {
+                                            requires_imports = true;
+                                        }
                                         FieldData {
-                                            name: field.name.to_snek_case(),
-                                            rust_type: rust_type.clone(),
-                                            is_pubkey: rust_type == "Pubkey",
+                                            name: field.name.to_upper_camel_case(),
+                                            rust_type: rust_type.0.clone(),
+                                            is_pubkey: rust_type.0 == "Pubkey",
                                             attributes: None,
                                         }
                                     })
                                     .collect();
                                 EnumVariantData {
-                                    name: name.clone(),
+                                    name: name.to_upper_camel_case().clone(),
                                     fields: Some(EnumVariantFields::Named(named_fields)),
                                 }
                             }
-                            EnumVariantTypeNode::EnumTupleVariantTypeNode { name, items } => {
-                                let unnamed_fields = items.iter().map(map_type).collect();
+                            EnumVariantTypeNode::EnumTupleVariantTypeNode { name, tuple } => {
+                                let unnamed_fields = tuple
+                                    .items
+                                    .iter()
+                                    .map(|item| {
+                                        let rust_type = map_type(item);
+                                        if rust_type.1 {
+                                            requires_imports = true;
+                                        }
+                                        rust_type.0.clone()
+                                    })
+                                    .collect();
                                 EnumVariantData {
-                                    name: name.clone(),
+                                    name: name.to_upper_camel_case().clone(),
                                     fields: Some(EnumVariantFields::Unnamed(unnamed_fields)),
                                 }
                             }
@@ -161,13 +194,37 @@ pub fn process_codama_defined_types(program: &ProgramNode) -> Vec<TypeData> {
             _ => continue, // Skip unsupported type nodes for now.
         }
 
-        types_data.push(TypeData {
-            name,
-            fields,
-            kind,
-            requires_imports,
-        });
+        let module_name = name.to_snek_case();
+        let struct_name = name.to_upper_camel_case();
+
+        if event_hints.contains(&name) {
+            let discriminator = get_event_discriminator(&name);
+            let args = fields
+                .into_iter()
+                .map(|f| crate::events::ArgumentData {
+                    name: f.name,
+                    rust_type: f.rust_type,
+                })
+                .collect();
+
+            let event = EventData {
+                struct_name,
+                module_name,
+                discriminator,
+                args,
+                requires_imports,
+            };
+
+            events_data.push(event);
+        } else {
+            types_data.push(TypeData {
+                name,
+                fields,
+                kind,
+                requires_imports,
+            });
+        }
     }
 
-    types_data
+    (types_data, events_data)
 }

--- a/crates/cli/src/handlers/codama/processors.rs
+++ b/crates/cli/src/handlers/codama/processors.rs
@@ -161,7 +161,7 @@ pub fn process_codama_defined_types(
                                                 requires_imports = true;
                                             }
                                             FieldData {
-                                                name: field.name.to_upper_camel_case(),
+                                                name: field.name.to_snek_case(),
                                                 rust_type: rust_type.0.clone(),
                                                 is_pubkey: rust_type.0 == "Pubkey",
                                                 attributes: None,

--- a/crates/cli/src/handlers/codama/processors.rs
+++ b/crates/cli/src/handlers/codama/processors.rs
@@ -11,7 +11,7 @@ use crate::{
     instructions::{AccountMetaData, ArgumentData, InstructionData},
     types::{EnumVariantData, EnumVariantFields, FieldData, TypeData, TypeKind},
 };
-use heck::{ToSnekCase, ToUpperCamelCase};
+use heck::{ToSnakeCase, ToUpperCamelCase};
 use std::collections::HashSet;
 
 pub fn process_codama_accounts(program: &ProgramNode) -> Vec<AccountData> {
@@ -21,7 +21,7 @@ pub fn process_codama_accounts(program: &ProgramNode) -> Vec<AccountData> {
         let mut requires_imports = false;
 
         let struct_name = account.name.to_upper_camel_case();
-        let module_name = account.name.to_snek_case();
+        let module_name = account.name.to_snake_case();
         let discriminator = get_account_discriminator(account, &account.name);
 
         let mut fields = Vec::new();

--- a/crates/cli/src/handlers/codama/processors.rs
+++ b/crates/cli/src/handlers/codama/processors.rs
@@ -1,0 +1,173 @@
+use super::{
+    types::{
+        AccountData, AccountMetaData, ArgumentData, EnumVariantData, EnumVariantFields,
+        EnumVariantTypeNode, FieldData, InstructionData, ProgramNode, TypeData, TypeKind, TypeNode,
+    },
+    utils::{get_instruction_discriminator, map_type},
+};
+use heck::{ToSnekCase, ToUpperCamelCase};
+
+pub fn process_codama_accounts(program: &ProgramNode) -> Vec<AccountData> {
+    let mut accounts_data = Vec::new();
+
+    for account in &program.accounts {
+        let mut requires_imports = false;
+
+        let struct_name = account.name.to_upper_camel_case();
+        let module_name = account.name.to_snek_case();
+        let discriminator = "".to_string(); // TODO: get discriminator as from ixs
+
+        let mut fields = Vec::new();
+        for field in &account.data.fields {
+            let rust_type = map_type(&field.field_type);
+            if rust_type.contains("Pubkey") {
+                requires_imports = true;
+            }
+
+            let is_pubkey = rust_type == "Pubkey";
+            fields.push(FieldData {
+                name: field.name.to_snek_case(),
+                rust_type,
+                is_pubkey,
+                attributes: None,
+            });
+        }
+
+        accounts_data.push(AccountData {
+            struct_name,
+            module_name,
+            discriminator,
+            fields,
+            requires_imports,
+        });
+    }
+
+    accounts_data
+}
+
+pub fn process_codama_instructions(program: &ProgramNode) -> Vec<InstructionData> {
+    let mut instructions_data = Vec::new();
+
+    for instruction in &program.instructions {
+        let mut requires_imports = false;
+
+        let struct_name = instruction.name.to_upper_camel_case();
+        let module_name = instruction.name.to_snek_case();
+        let discriminator =
+            get_instruction_discriminator(&instruction.arguments, &instruction.name);
+
+        let mut args = Vec::new();
+        for arg in &instruction.arguments {
+            let rust_type = map_type(&arg.arg_type);
+            if rust_type.contains("Pubkey") {
+                requires_imports = true;
+            }
+            args.push(ArgumentData {
+                name: arg.name.to_snek_case(),
+                rust_type,
+            });
+        }
+
+        let mut accounts = Vec::new();
+        for account in &instruction.accounts {
+            accounts.push(AccountMetaData {
+                name: account.name.to_snek_case(),
+                is_mut: account.is_writable,
+                is_signer: account.is_signer,
+            });
+        }
+
+        instructions_data.push(InstructionData {
+            struct_name,
+            module_name,
+            discriminator,
+            args,
+            accounts,
+            requires_imports,
+        });
+    }
+
+    instructions_data
+}
+
+pub fn process_codama_defined_types(program: &ProgramNode) -> Vec<TypeData> {
+    let mut types_data = Vec::new();
+
+    for defined_type in &program.defined_types {
+        let mut requires_imports = false;
+
+        let name = defined_type.name.clone();
+        let mut fields = Vec::new();
+        let mut kind = TypeKind::Struct;
+
+        match &defined_type.data {
+            TypeNode::StructTypeNode {
+                fields: struct_fields,
+            } => {
+                for field in struct_fields {
+                    let rust_type = map_type(&field.field_type);
+                    if rust_type.contains("Pubkey") {
+                        requires_imports = true;
+                    }
+                    let is_pubkey = rust_type == "Pubkey";
+                    fields.push(FieldData {
+                        name: field.name.to_snek_case(),
+                        rust_type,
+                        is_pubkey,
+                        attributes: None,
+                    });
+                }
+            }
+            TypeNode::EnumTypeNode { variants } => {
+                kind = TypeKind::Enum(
+                    variants
+                        .iter()
+                        .map(|variant| match variant {
+                            EnumVariantTypeNode::EnumEmptyVariantTypeNode { name } => {
+                                EnumVariantData {
+                                    name: name.clone(),
+                                    fields: None,
+                                }
+                            }
+                            EnumVariantTypeNode::EnumStructVariantTypeNode { name, fields } => {
+                                let named_fields = fields
+                                    .iter()
+                                    .map(|field| {
+                                        let rust_type = map_type(&field.field_type);
+                                        FieldData {
+                                            name: field.name.to_snek_case(),
+                                            rust_type: rust_type.clone(),
+                                            is_pubkey: rust_type == "Pubkey",
+                                            attributes: None,
+                                        }
+                                    })
+                                    .collect();
+                                EnumVariantData {
+                                    name: name.clone(),
+                                    fields: Some(EnumVariantFields::Named(named_fields)),
+                                }
+                            }
+                            EnumVariantTypeNode::EnumTupleVariantTypeNode { name, items } => {
+                                let unnamed_fields = items.iter().map(map_type).collect();
+                                EnumVariantData {
+                                    name: name.clone(),
+                                    fields: Some(EnumVariantFields::Unnamed(unnamed_fields)),
+                                }
+                            }
+                        })
+                        .collect(),
+                );
+            }
+            _ => continue, // Skip unsupported type nodes for now.
+        }
+
+        types_data.push(TypeData {
+            name,
+            fields,
+            kind,
+            requires_imports,
+        });
+    }
+
+    types_data
+}

--- a/crates/cli/src/handlers/codama/types.rs
+++ b/crates/cli/src/handlers/codama/types.rs
@@ -1,0 +1,222 @@
+use serde::{Deserialize, Serialize};
+
+// ----------------------- Codama Types -----------------------
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RootNode {
+    pub program: ProgramNode,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProgramNode {
+    pub name: String,
+    pub accounts: Vec<AccountNode>,
+    pub instructions: Vec<InstructionNode>,
+    pub defined_types: Vec<DefinedTypeNode>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountNode {
+    pub name: String,
+    pub data: StructTypeNode,
+    pub discriminators: Vec<FieldDiscriminatorNode>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InstructionNode {
+    pub name: String,
+    pub accounts: Vec<InstructionAccountNode>,
+    pub arguments: Vec<InstructionArgumentNode>,
+    pub discriminators: Vec<FieldDiscriminatorNode>, // Not sure if needed yet
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DefinedTypeNode {
+    pub name: String,
+    pub data: TypeNode,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StructTypeNode {
+    pub fields: Vec<StructFieldTypeNode>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StructFieldTypeNode {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub field_type: TypeNode,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum TypeNode {
+    NumberTypeNode {
+        format: String,
+        endian: String,
+    },
+    PublicKeyTypeNode,
+    BooleanTypeNode {
+        size: NumberTypeNode,
+    },
+    FixedSizeTypeNode {
+        size: usize,
+        r#type: Box<TypeNode>,
+    },
+    OptionTypeNode {
+        item: Box<TypeNode>,
+        prefix: NumberTypeNode,
+    },
+    DefinedTypeLinkNode {
+        name: String,
+    },
+    BytesTypeNode,
+    SizePrefixTypeNode {
+        r#type: Box<TypeNode>,
+        prefix: NumberTypeNode,
+    },
+    StringTypeNode {
+        encoding: String,
+    },
+    StructTypeNode {
+        fields: Vec<StructFieldTypeNode>,
+    },
+    EnumTypeNode {
+        variants: Vec<EnumVariantTypeNode>,
+    },
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum ValueNode {
+    BytesValueNode { data: String, encoding: String },
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum EnumVariantTypeNode {
+    EnumEmptyVariantTypeNode {
+        name: String,
+    },
+    EnumStructVariantTypeNode {
+        name: String,
+        fields: Vec<StructFieldTypeNode>,
+    },
+    EnumTupleVariantTypeNode {
+        name: String,
+        items: Vec<TypeNode>,
+    },
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NumberTypeNode {
+    pub format: String,
+    pub endian: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FieldDiscriminatorNode {
+    pub name: String,
+    pub offset: usize,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InstructionAccountNode {
+    pub name: String,
+    pub is_writable: bool,
+    pub is_signer: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InstructionArgumentNode {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub arg_type: TypeNode,
+    pub default_value: Option<DefaultValue>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DefaultValue {
+    pub kind: ValueNode,
+    pub data: Option<String>,
+}
+
+// ----------------------- Decoder Types -----------------------
+
+#[derive(Debug)]
+pub struct AccountData {
+    pub struct_name: String,
+    pub module_name: String,
+    pub discriminator: String,
+    pub fields: Vec<FieldData>,
+    pub requires_imports: bool,
+}
+
+#[derive(Debug)]
+pub struct InstructionData {
+    pub struct_name: String,
+    pub module_name: String,
+    pub discriminator: String,
+    pub args: Vec<ArgumentData>,
+    pub accounts: Vec<AccountMetaData>,
+    pub requires_imports: bool,
+}
+
+#[derive(Debug)]
+pub struct TypeData {
+    pub name: String,
+    pub fields: Vec<FieldData>,
+    pub kind: TypeKind,
+    pub requires_imports: bool,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum TypeKind {
+    Struct,
+    Enum(Vec<EnumVariantData>),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct FieldData {
+    pub name: String,
+    pub rust_type: String,
+    pub is_pubkey: bool,
+    pub attributes: Option<String>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct EnumVariantData {
+    pub name: String,
+    pub fields: Option<EnumVariantFields>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum EnumVariantFields {
+    Named(Vec<FieldData>),
+    Unnamed(Vec<String>),
+}
+
+#[derive(Debug)]
+pub struct ArgumentData {
+    pub name: String,
+    pub rust_type: String,
+}
+
+#[derive(Debug)]
+pub struct AccountMetaData {
+    pub name: String,
+    pub is_mut: bool,
+    pub is_signer: bool,
+}

--- a/crates/cli/src/handlers/codama/utils.rs
+++ b/crates/cli/src/handlers/codama/utils.rs
@@ -1,0 +1,42 @@
+use sha2::{Digest, Sha256};
+
+use crate::handlers::codama::types::ValueNode;
+
+use super::types::{FieldDiscriminatorNode, InstructionArgumentNode, TypeNode};
+
+pub fn map_type(type_node: &TypeNode) -> String {
+    match type_node {
+        TypeNode::NumberTypeNode { format, .. } => format!("{}", format),
+        TypeNode::PublicKeyTypeNode => "Pubkey".to_string(),
+        TypeNode::BooleanTypeNode { .. } => "bool".to_string(),
+        TypeNode::FixedSizeTypeNode { size, r#type } => format!("[{}; {}]", map_type(r#type), size),
+        TypeNode::OptionTypeNode { item, .. } => format!("Option<{}>", map_type(item)),
+        TypeNode::DefinedTypeLinkNode { name } => name.clone(),
+        TypeNode::BytesTypeNode => "Vec<u8>".to_string(),
+        TypeNode::StringTypeNode { .. } => "String".to_string(),
+        _ => "UnsupportedType".to_string(),
+    }
+}
+
+pub fn get_instruction_discriminator(
+    ix_arguments: &[InstructionArgumentNode],
+    instruction_name: &str,
+) -> String {
+    if let Some(first_argument) = ix_arguments.get(0) {
+        if first_argument.name == "discriminator" {
+            if let Some(default_value) = &first_argument.default_value {
+                let ValueNode::BytesValueNode { data, encoding } = &default_value.kind;
+                if encoding == "base16" {
+                    return format!("0x{}", data);
+                }
+            }
+        }
+    }
+
+    let mut hasher = Sha256::new();
+    let discriminator_input = format!("global:{}", instruction_name);
+    hasher.update(discriminator_input.as_bytes());
+    let hash = hasher.finalize();
+    let discriminator_bytes = &hash[..8];
+    format!("0x{}", hex::encode(discriminator_bytes))
+}

--- a/crates/cli/src/handlers/codama/utils.rs
+++ b/crates/cli/src/handlers/codama/utils.rs
@@ -1,20 +1,39 @@
-use sha2::{Digest, Sha256};
-
+use super::types::{AccountNode, InstructionArgumentNode, RootNode, TypeNode};
 use crate::handlers::codama::types::ValueNode;
+use anyhow::Result;
+use heck::ToUpperCamelCase;
+use sha2::{Digest, Sha256};
+use std::{collections::HashSet, fs::File};
 
-use super::types::{FieldDiscriminatorNode, InstructionArgumentNode, TypeNode};
-
-pub fn map_type(type_node: &TypeNode) -> String {
+pub fn map_type(type_node: &TypeNode) -> (String, bool) {
     match type_node {
-        TypeNode::NumberTypeNode { format, .. } => format!("{}", format),
-        TypeNode::PublicKeyTypeNode => "Pubkey".to_string(),
-        TypeNode::BooleanTypeNode { .. } => "bool".to_string(),
-        TypeNode::FixedSizeTypeNode { size, r#type } => format!("[{}; {}]", map_type(r#type), size),
-        TypeNode::OptionTypeNode { item, .. } => format!("Option<{}>", map_type(item)),
-        TypeNode::DefinedTypeLinkNode { name } => name.clone(),
-        TypeNode::BytesTypeNode => "Vec<u8>".to_string(),
-        TypeNode::StringTypeNode { .. } => "String".to_string(),
-        _ => "UnsupportedType".to_string(),
+        TypeNode::NumberTypeNode { format, .. } => (format!("{}", format), false),
+        TypeNode::PublicKeyTypeNode => ("solana_sdk::pubkey::Pubkey".to_string(), false),
+        TypeNode::BooleanTypeNode { .. } => ("bool".to_string(), false),
+        TypeNode::FixedSizeTypeNode { size, r#type } => {
+            let (rust_type, requres_import) = map_type(r#type);
+            (format!("[{}; {}]", rust_type, size), requres_import)
+        }
+        TypeNode::OptionTypeNode { item, .. } => {
+            let (rust_type, requres_import) = map_type(item);
+            (format!("Option<{}>", rust_type), requres_import)
+        }
+        TypeNode::DefinedTypeLinkNode { name } => (name.to_upper_camel_case().clone(), true),
+        TypeNode::BytesTypeNode => ("u8".to_string(), false),
+        TypeNode::StringTypeNode { .. } => ("String".to_string(), false),
+        TypeNode::SolAmountTypeNode { number } => {
+            let inner = map_type(number);
+            (format!("{}", inner.0), inner.1)
+        }
+        TypeNode::SizePrefixTypeNode { r#type, .. } => {
+            let inner = map_type(r#type);
+            (format!("{}", inner.0), inner.1)
+        }
+        TypeNode::ArrayTypeNode { item, count } => {
+            let (rust_type, requires_import) = map_type(item);
+            (format!("[{}; {}]", rust_type, count.value), requires_import)
+        }
+        _ => ("UnsupportedType".to_string(), false),
     }
 }
 
@@ -25,9 +44,24 @@ pub fn get_instruction_discriminator(
     if let Some(first_argument) = ix_arguments.get(0) {
         if first_argument.name == "discriminator" {
             if let Some(default_value) = &first_argument.default_value {
-                let ValueNode::BytesValueNode { data, encoding } = &default_value.kind;
-                if encoding == "base16" {
-                    return format!("0x{}", data);
+                match default_value {
+                    ValueNode::BytesValueNode { data, encoding } if encoding == "base16" => {
+                        return format!("0x{}", data);
+                    }
+                    ValueNode::NumberValueNode { number } => {
+                        if let TypeNode::NumberTypeNode { format, .. } = &first_argument.arg_type {
+                            let bytes = match format.as_str() {
+                                "u8" => vec![*number as u8],
+                                "u16" => (*number as u16).to_le_bytes().to_vec(),
+                                "u32" => (*number as u32).to_le_bytes().to_vec(),
+                                "u64" => number.to_le_bytes().to_vec(),
+                                _ => [0u8; 8].to_vec(),
+                            };
+
+                            return format!("0x{}", hex::encode(&bytes));
+                        }
+                    }
+                    _ => {}
                 }
             }
         }
@@ -39,4 +73,70 @@ pub fn get_instruction_discriminator(
     let hash = hasher.finalize();
     let discriminator_bytes = &hash[..8];
     format!("0x{}", hex::encode(discriminator_bytes))
+}
+
+pub fn get_account_discriminator(account_node: &AccountNode, account_name: &str) -> String {
+    if let Some(first_data_field) = account_node.data.fields.get(0) {
+        if first_data_field.name == "discriminator" {
+            if let Some(default_value) = &first_data_field.default_value {
+                match default_value {
+                    ValueNode::BytesValueNode { data, encoding } if encoding == "base16" => {
+                        return format!("0x{}", data);
+                    }
+                    ValueNode::NumberValueNode { number } => {
+                        if let TypeNode::NumberTypeNode { format, .. } =
+                            &first_data_field.field_type
+                        {
+                            let bytes = match format.as_str() {
+                                "u8" => vec![*number as u8],
+                                "u16" => (*number as u16).to_le_bytes().to_vec(),
+                                "u32" => (*number as u32).to_le_bytes().to_vec(),
+                                "u64" => number.to_le_bytes().to_vec(),
+                                _ => [0u8; 8].to_vec(),
+                            };
+
+                            return format!("0x{}", hex::encode(&bytes));
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    let mut hasher = Sha256::new();
+    let discriminator_input = format!("account:{}", account_name);
+    hasher.update(discriminator_input.as_bytes());
+    let hash = hasher.finalize();
+    let discriminator_bytes = &hash[..8];
+    format!("0x{}", hex::encode(discriminator_bytes))
+}
+
+pub fn get_event_discriminator(event_name: &str) -> String {
+    let mut hasher = Sha256::new();
+    let discriminator_input = format!("event:{}", event_name);
+    hasher.update(discriminator_input.as_bytes());
+    let hash = hasher.finalize();
+    let discriminator_bytes = &hash[..8];
+    format!("0xe445a52e51cb9a1d{}", hex::encode(discriminator_bytes))
+}
+
+pub fn read_codama_idl(idl_path: &str) -> Result<RootNode> {
+    let file = File::open(idl_path).unwrap();
+    match serde_json::from_reader(file) {
+        Ok(idl) => Ok(idl),
+        Err(e) => {
+            println!("Error parsing Codama IDL: {:?}", e);
+            anyhow::bail!("Error parsing  Codama idl: {:?}", e);
+        }
+    }
+}
+
+pub fn parse_event_hints(hints: Option<String>) -> HashSet<String> {
+    hints
+        .unwrap_or("".to_string())
+        .split(',')
+        .map(|s| s.trim().to_string().to_upper_camel_case())
+        .filter(|s| !s.is_empty())
+        .collect()
 }

--- a/crates/cli/src/handlers/mod.rs
+++ b/crates/cli/src/handlers/mod.rs
@@ -1,5 +1,8 @@
 mod parse;
 pub use parse::*;
 
+mod codama;
+pub use codama::*;
+
 mod process_pda_idl;
 pub use process_pda_idl::*;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -21,8 +21,16 @@ fn main() -> Result<()> {
         Commands::Parse(options) => match options.idl {
             IdlSource::FilePath(path) => {
                 if options.codama {
-                    handlers::parse_codama(path, options.output, options.as_crate)?;
+                    handlers::parse_codama(
+                        path,
+                        options.output,
+                        options.as_crate,
+                        options.event_hints,
+                    )?;
                 } else {
+                    if options.event_hints.is_some() {
+                        anyhow::bail!("The '--event-hints' option can only be used with --codama.");
+                    }
                     handlers::parse(path, options.output, options.as_crate)?;
                 }
             }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use clap::Parser;
-use commands::{Cli, Commands, IdlSource};
+use commands::{Cli, Commands, IdlSource, IdlStandard};
 
 pub mod accounts;
 pub mod commands;
@@ -19,21 +19,22 @@ fn main() -> Result<()> {
 
     match cli.command {
         Commands::Parse(options) => match options.idl {
-            IdlSource::FilePath(path) => {
-                if options.codama {
+            IdlSource::FilePath(path) => match options.standard {
+                IdlStandard::Codama => {
                     handlers::parse_codama(
                         path,
                         options.output,
                         options.as_crate,
                         options.event_hints,
                     )?;
-                } else {
+                }
+                IdlStandard::Anchor => {
                     if options.event_hints.is_some() {
                         anyhow::bail!("The '--event-hints' option can only be used with --codama.");
                     }
                     handlers::parse(path, options.output, options.as_crate)?;
                 }
-            }
+            },
             IdlSource::ProgramAddress(program_address) => {
                 let url = options
                     .url

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -20,7 +20,11 @@ fn main() -> Result<()> {
     match cli.command {
         Commands::Parse(options) => match options.idl {
             IdlSource::FilePath(path) => {
-                handlers::parse(path, options.output, options.as_crate)?;
+                if options.codama {
+                    handlers::parse_codama(path, options.output, options.as_crate)?;
+                } else {
+                    handlers::parse(path, options.output, options.as_crate)?;
+                }
             }
             IdlSource::ProgramAddress(program_address) => {
                 let url = options


### PR DESCRIPTION
The commit adds support for Codama IDLs parsing. 

The current version was tested with the following programs: System, SPL Token, Memo, Ore and one of our private Anchor program.

The most important types were added to parse most of the programs' Codama IDLs. We still might encounter cases where a certain type isn't covered causing a parsing error, which can be fixed quickly.