### PR TITLE
fix: restore usage of datasize instead of generated decoder from CLI

### DIFF
--- a/decoders/raydium-amm-v4-decoder/src/accounts/amm_info.rs
+++ b/decoders/raydium-amm-v4-decoder/src/accounts/amm_info.rs
@@ -3,8 +3,9 @@ use {
     carbon_core::{borsh, CarbonDeserialize},
 };
 
+pub(crate) const AMM_INFO_SIZE: usize = std::mem::size_of::<AmmInfo>();
+
 #[derive(CarbonDeserialize, Debug)]
-#[carbon(discriminator = "0x21d902cbb853eb5b")]
 pub struct AmmInfo {
     pub status: u64,
     pub nonce: u64,

--- a/decoders/raydium-amm-v4-decoder/src/accounts/fees.rs
+++ b/decoders/raydium-amm-v4-decoder/src/accounts/fees.rs
@@ -5,7 +5,6 @@ pub(crate) const FEES_SIZE: usize = std::mem::size_of::<Fees>();
 #[derive(
     CarbonDeserialize, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq, Clone, Hash,
 )]
-#[carbon(discriminator = "0x979d32738248b324")]
 pub struct Fees {
     pub min_separate_numerator: u64,
     pub min_separate_denominator: u64,

--- a/decoders/raydium-amm-v4-decoder/src/accounts/mod.rs
+++ b/decoders/raydium-amm-v4-decoder/src/accounts/mod.rs
@@ -6,6 +6,7 @@ pub mod amm_info;
 pub mod fees;
 pub mod target_orders;
 
+#[allow(clippy::large_enum_variant)]
 pub enum RaydiumAmmV4Account {
     TargetOrders(target_orders::TargetOrders),
     Fees(fees::Fees),
@@ -18,38 +19,41 @@ impl AccountDecoder<'_> for RaydiumAmmV4Decoder {
         &self,
         account: &solana_sdk::account::Account,
     ) -> Option<carbon_core::account::DecodedAccount<Self::AccountType>> {
-        if let Some(decoded_account) =
-            target_orders::TargetOrders::deserialize(account.data.as_slice())
-        {
-            return Some(carbon_core::account::DecodedAccount {
-                lamports: account.lamports,
-                data: RaydiumAmmV4Account::TargetOrders(decoded_account),
-                owner: account.owner,
-                executable: account.executable,
-                rent_epoch: account.rent_epoch,
-            });
-        }
+        let data_size = account.data.len();
 
-        if let Some(decoded_account) = fees::Fees::deserialize(account.data.as_slice()) {
-            return Some(carbon_core::account::DecodedAccount {
-                lamports: account.lamports,
-                data: RaydiumAmmV4Account::Fees(decoded_account),
-                owner: account.owner,
-                executable: account.executable,
-                rent_epoch: account.rent_epoch,
-            });
+        match data_size {
+            amm_info::AMM_INFO_SIZE => {
+                let decoded_account = amm_info::AmmInfo::deserialize(account.data.as_slice())?;
+                Some(carbon_core::account::DecodedAccount {
+                    lamports: account.lamports,
+                    data: RaydiumAmmV4Account::AmmInfo(decoded_account),
+                    owner: account.owner,
+                    executable: account.executable,
+                    rent_epoch: account.rent_epoch,
+                })
+            }
+            fees::FEES_SIZE => {
+                let decoded_account = fees::Fees::deserialize(account.data.as_slice())?;
+                Some(carbon_core::account::DecodedAccount {
+                    lamports: account.lamports,
+                    data: RaydiumAmmV4Account::Fees(decoded_account),
+                    owner: account.owner,
+                    executable: account.executable,
+                    rent_epoch: account.rent_epoch,
+                })
+            }
+            target_orders::TARGET_ORDERS_SIZE => {
+                let decoded_account =
+                    target_orders::TargetOrders::deserialize(account.data.as_slice())?;
+                Some(carbon_core::account::DecodedAccount {
+                    lamports: account.lamports,
+                    data: RaydiumAmmV4Account::TargetOrders(decoded_account),
+                    owner: account.owner,
+                    executable: account.executable,
+                    rent_epoch: account.rent_epoch,
+                })
+            }
+            _ => None,
         }
-
-        if let Some(decoded_account) = amm_info::AmmInfo::deserialize(account.data.as_slice()) {
-            return Some(carbon_core::account::DecodedAccount {
-                lamports: account.lamports,
-                data: RaydiumAmmV4Account::AmmInfo(decoded_account),
-                owner: account.owner,
-                executable: account.executable,
-                rent_epoch: account.rent_epoch,
-            });
-        }
-
-        None
     }
 }

--- a/decoders/raydium-amm-v4-decoder/src/accounts/target_orders.rs
+++ b/decoders/raydium-amm-v4-decoder/src/accounts/target_orders.rs
@@ -3,8 +3,9 @@ use {
     carbon_core::{borsh, CarbonDeserialize},
 };
 
+pub(crate) const TARGET_ORDERS_SIZE: usize = std::mem::size_of::<TargetOrders>();
+
 #[derive(CarbonDeserialize, Debug)]
-#[carbon(discriminator = "0x71e18cff4190efe7")]
 pub struct TargetOrders {
     pub owner: [u64; 4],
     pub buy_orders: [TargetOrder; 50],


### PR DESCRIPTION
closes #162 