### PR TITLE
fix: Specific full import path for BigArray

### DIFF
--- a/crates/cli/src/types.rs
+++ b/crates/cli/src/types.rs
@@ -72,7 +72,7 @@ pub fn legacy_process_types(idl: &LegacyIdl) -> Vec<TypeData> {
                         }
                         let is_pubkey = rust_type.0.contains("Pubkey");
                         let attributes = if is_big_array(&rust_type.0) {
-                            Some("#[serde(with = \"BigArray\")]".to_string())
+                            Some("#[serde(with = \"serde_big_array::BigArray\")]".to_string())
                         } else {
                             None
                         };


### PR DESCRIPTION
I had to manually import the `serde_big_array` crate if dont have this  