### PR TITLE
fix(decoder): Compare type name with event name with Event suffix

### DIFF
--- a/crates/cli/src/events.rs
+++ b/crates/cli/src/events.rs
@@ -94,7 +94,8 @@ pub fn process_events(idl: &Idl) -> Vec<EventData> {
         let mut args = Vec::new();
 
         for ty in &idl.types {
-            if ty.name == struct_name {
+            // type name doesnt have Event suffix, but the struct_name has
+            if ty.name == event.name.to_upper_camel_case() {
                 if let Some(fields) = &ty.type_.fields {
                     for field in fields {
                         let rust_type = idl_type_to_rust_type(&field.type_);

--- a/crates/cli/src/events.rs
+++ b/crates/cli/src/events.rs
@@ -95,7 +95,7 @@ pub fn process_events(idl: &Idl) -> Vec<EventData> {
 
         for ty in &idl.types {
             // type name doesnt have Event suffix, but the struct_name has
-            if ty.name == event.name.to_upper_camel_case() {
+            if ty.name == struct_name.trim_end_matches("Event") {
                 if let Some(fields) = &ty.type_.fields {
                     for field in fields {
                         let rust_type = idl_type_to_rust_type(&field.type_);


### PR DESCRIPTION
# Context
The event CPI when parsed doesn't have fields inside struct. The reason is the comparing between type name and event name.