### PR TITLE
feat: set is_vote to false in jito shredstream grpc

### DIFF
--- a/datasources/jito-shredstream-grpc-datasource/src/lib.rs
+++ b/datasources/jito-shredstream-grpc-datasource/src/lib.rs
@@ -101,14 +101,10 @@ impl Datasource for JitoShredstreamGrpcClient {
                         for entry in entries {
                             for transaction in entry.transactions {
                                 let signature = *transaction.get_signature();
-                                let is_vote = transaction.message.instructions().len() == 1
-                                    && solana_sdk::vote::program::id()
-                                        .eq(transaction.message.instructions()[0]
-                                            .program_id(transaction.message.static_account_keys()));
                               
                                 let update = Update::Transaction(Box::new(TransactionUpdate {
                                     signature,
-                                    is_vote,
+                                    is_vote: false,
                                     transaction,
                                     meta: TransactionStatusMeta {
                                         status: Ok(()),


### PR DESCRIPTION
I think it's a bad idea to try to check if a transaction is vote or no. For example if a transaction is (voluntarily) malformed and static accounts keys are empty it will panic.