### PR TITLE
fix(raydium-alerts): pin rustls 0.23 and install aws_lc_rs CryptoProvider to stop startup panic #259

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4765,6 +4765,7 @@ dependencies = [
  "dotenv",
  "env_logger",
  "log",
+ "rustls 0.23.26",
  "solana-client",
  "solana-pubkey",
  "solana-sdk",

--- a/examples/raydium-alerts/Cargo.toml
+++ b/examples/raydium-alerts/Cargo.toml
@@ -18,3 +18,8 @@ env_logger = { workspace = true }
 log = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 yellowstone-grpc-proto = { workspace = true }
+
+[dependencies.rustls]
+default-features = false
+features = ["std"]
+version = "0.23.0"

--- a/examples/raydium-alerts/src/main.rs
+++ b/examples/raydium-alerts/src/main.rs
@@ -32,6 +32,11 @@ pub async fn main() -> CarbonResult<()> {
     env_logger::init();
     dotenv::dotenv().ok();
 
+    // NOTE: Workaround, that solving issue https://github.com/rustls/rustls/issues/1877
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("Can't set crypto provider to aws_lc_rs");
+
     let mut account_filters: HashMap<String, SubscribeRequestFilterAccounts> = HashMap::new();
     account_filters.insert(
         "raydium_account_filter".to_string(),


### PR DESCRIPTION
The example crashed on launch with no process-level CryptoProvider available, because rustls ≥ 0.23 no longer installs a default provider (rustls #1877).

Workaround:
- Add explicit rustls = "0.23.0" dependency (std feature only, no default features).
- Call `rustls::crypto::aws_lc_rs::default_provider().install_default()` at program start.

Service now starts cleanly on carbon 0.8.0 with carbon‑yellowstone‑grpc‑datasource.

Related issue is: #259