### PR TITLE
pipeline datasource filters

### DIFF
--- a/crates/core/src/datasource.rs
+++ b/crates/core/src/datasource.rs
@@ -102,6 +102,7 @@ use {
 pub trait Datasource: Send + Sync {
     async fn consume(
         &self,
+        name: String,
         sender: tokio::sync::mpsc::Sender<Update>,
         cancellation_token: CancellationToken,
         metrics: Arc<MetricsCollection>,
@@ -149,11 +150,13 @@ pub enum UpdateType {
 /// - `pubkey`: The public key of the account being updated.
 /// - `account`: The new state of the account.
 /// - `slot`: The slot number in which this account update was recorded.
+/// - `source`: A string identifying the datasource that produced this update.
 #[derive(Debug, Clone)]
 pub struct AccountUpdate {
     pub pubkey: Pubkey,
     pub account: Account,
     pub slot: u64,
+    pub source: String,
 }
 
 /// Represents the details of a Solana block, including its slot, hashes, rewards, and timing information.
@@ -192,6 +195,7 @@ pub struct BlockDetails {
 pub struct AccountDeletion {
     pub pubkey: Pubkey,
     pub slot: u64,
+    pub source: String,
 }
 
 /// Represents a transaction update in the Solana network, including transaction
@@ -222,4 +226,5 @@ pub struct TransactionUpdate {
     pub slot: u64,
     pub block_time: Option<i64>,
     pub block_hash: Option<Hash>,
+    pub source: String,
 }

--- a/crates/core/src/transformers.rs
+++ b/crates/core/src/transformers.rs
@@ -494,6 +494,7 @@ pub fn transaction_metadata_from_original_meta(
 
 #[cfg(test)]
 mod tests {
+    use solana_signature::Signature;
     use {
         super::*,
         crate::instruction::{InstructionsWithMetadata, NestedInstructions},
@@ -505,10 +506,11 @@ mod tests {
             v0::{self, MessageAddressTableLookup},
             MessageHeader,
         },
-        solana_signature::Signature,
         solana_transaction::versioned::VersionedTransaction,
         std::vec,
     };
+
+    use crate::pipeline::GENERIC_DATASOURCE_NAME;
 
     #[test]
     fn test_transaction_metadata_from_original_meta_simple() {
@@ -691,6 +693,7 @@ mod tests {
         let original_tx_meta = transaction_metadata_from_original_meta(tx_meta_status)
             .expect("transaction metadata from original meta");
         let transaction_update = TransactionUpdate {
+            source: GENERIC_DATASOURCE_NAME.into(),
             signature: Signature::default(),
             transaction: VersionedTransaction {
                 signatures: vec![Signature::default()],
@@ -1092,6 +1095,7 @@ mod tests {
         let original_tx_meta = transaction_metadata_from_original_meta(tx_meta_status)
             .expect("transaction metadata from original meta");
         let transaction_update = TransactionUpdate {
+            source: GENERIC_DATASOURCE_NAME.into(),
             signature: Signature::default(),
             transaction: VersionedTransaction {
                 signatures: vec![Signature::default()],

--- a/datasources/helius-atlas-ws-datasource/src/lib.rs
+++ b/datasources/helius-atlas-ws-datasource/src/lib.rs
@@ -94,6 +94,7 @@ impl HeliusWebsocket {
 impl Datasource for HeliusWebsocket {
     async fn consume(
         &self,
+        name: String,
         sender: Sender<Update>,
         cancellation_token: CancellationToken,
         metrics: Arc<MetricsCollection>,
@@ -161,6 +162,7 @@ impl Datasource for HeliusWebsocket {
 
             let main_cancellation = cancellation_token.clone();
 
+            let name = name.clone();
             let handle = tokio::spawn(async move {
                 let mut handles = vec![];
 
@@ -261,6 +263,7 @@ impl Datasource for HeliusWebsocket {
                         let account_deletions_tracked = Arc::clone(&account_deletions_tracked);
                         let metrics = metrics.clone();
 
+                        let name = name.clone();
                         let handle = tokio::spawn(async move {
                             let ws = match helius_clone.ws() {
                                 Some(ws) => ws,
@@ -312,6 +315,7 @@ impl Datasource for HeliusWebsocket {
                                                         let account_deletion = AccountDeletion {
                                                             pubkey: account,
                                                             slot: acc_event.context.slot,
+                                                            source: name.clone(),
                                                         };
 
                                                         metrics.record_histogram("helius_atlas_ws_account_deletion_process_time_nanoseconds", start_time.elapsed().as_nanos() as f64).await.unwrap_or_else(|value| log::error!("Error recording metric: {}", value));
@@ -331,6 +335,7 @@ impl Datasource for HeliusWebsocket {
                                                         pubkey: account,
                                                         account: decoded_account,
                                                         slot: acc_event.context.slot,
+                                                        source: name.clone(),
                                                     });
 
                                                     metrics.record_histogram("helius_atlas_ws_account_process_time_nanoseconds", start_time.elapsed().as_nanos() as f64).await.unwrap_or_else(|value| log::error!("Error recording metric: {}", value));
@@ -584,6 +589,7 @@ impl Datasource for HeliusWebsocket {
                                                 slot: tx_event.slot,
                                                 block_time: None,
                                                 block_hash: None,
+                                                source: name.clone(),
                                             }));
 
                                             metrics

--- a/datasources/jito-shredstream-grpc-datasource/src/lib.rs
+++ b/datasources/jito-shredstream-grpc-datasource/src/lib.rs
@@ -34,6 +34,7 @@ impl JitoShredstreamGrpcClient {
 impl Datasource for JitoShredstreamGrpcClient {
     async fn consume(
         &self,
+        name: String,
         sender: Sender<Update>,
         cancellation_token: CancellationToken,
         metrics: Arc<MetricsCollection>,
@@ -87,6 +88,7 @@ impl Datasource for JitoShredstreamGrpcClient {
                     let metrics = metrics.clone();
                     let sender = sender.clone();
                     let dedup_cache = dedup_cache.clone();
+                    let name = name.clone();
 
                     async move {
                         let start_time = SystemTime::now();
@@ -125,6 +127,7 @@ impl Datasource for JitoShredstreamGrpcClient {
                                     slot: message.slot,
                                     block_time,
                                     block_hash: None,
+                                    source: name.clone(),
                                 }));
 
                                 if let Err(e) = sender.try_send(update) {

--- a/datasources/rpc-block-crawler-datasource/src/lib.rs
+++ b/datasources/rpc-block-crawler-datasource/src/lib.rs
@@ -66,6 +66,7 @@ impl RpcBlockCrawler {
 impl Datasource for RpcBlockCrawler {
     async fn consume(
         &self,
+        name: String,
         sender: Sender<Update>,
         cancellation_token: CancellationToken,
         metrics: Arc<MetricsCollection>,
@@ -91,6 +92,7 @@ impl Datasource for RpcBlockCrawler {
         );
 
         let task_processor = task_processor(
+            name,
             block_receiver,
             sender,
             cancellation_token.clone(),
@@ -246,6 +248,7 @@ fn block_fetcher(
 
 /// Process the block and send the transactions to the sender
 fn task_processor(
+    name: String,
     block_receiver: Receiver<(u64, UiConfirmedBlock)>,
     sender: Sender<Update>,
     cancellation_token: CancellationToken,
@@ -304,6 +307,7 @@ fn task_processor(
                                     slot,
                                     block_time: block.block_time,
                                     block_hash,
+                                    source: name.clone(),
                                 }));
 
                                 metrics

--- a/datasources/rpc-block-subscribe-datasource/src/lib.rs
+++ b/datasources/rpc-block-subscribe-datasource/src/lib.rs
@@ -61,6 +61,7 @@ impl RpcBlockSubscribe {
 impl Datasource for RpcBlockSubscribe {
     async fn consume(
         &self,
+        name: String,
         sender: Sender<Update>,
         cancellation_token: CancellationToken,
         metrics: Arc<MetricsCollection>,
@@ -176,6 +177,7 @@ impl Datasource for RpcBlockSubscribe {
                                                 slot,
                                                 block_time: block.block_time,
                                                 block_hash,
+                                                source: name.clone(),
                                             }));
 
                                             metrics

--- a/datasources/rpc-program-subscribe-datasource/src/lib.rs
+++ b/datasources/rpc-program-subscribe-datasource/src/lib.rs
@@ -55,6 +55,7 @@ impl RpcProgramSubscribe {
 impl Datasource for RpcProgramSubscribe {
     async fn consume(
         &self,
+        name: String,
         sender: Sender<Update>,
         cancellation_token: CancellationToken,
         metrics: Arc<MetricsCollection>,
@@ -134,6 +135,7 @@ impl Datasource for RpcProgramSubscribe {
                                     pubkey: account_pubkey,
                                     account: decoded_account,
                                     slot: acc_event.context.slot,
+                                    source: name.clone(),
                                 });
 
                                 metrics

--- a/datasources/rpc-transaction-crawler-datasource/src/lib.rs
+++ b/datasources/rpc-transaction-crawler-datasource/src/lib.rs
@@ -83,6 +83,7 @@ impl RpcTransactionCrawler {
 impl Datasource for RpcTransactionCrawler {
     async fn consume(
         &self,
+        name: String,
         sender: Sender<Update>,
         cancellation_token: CancellationToken,
         metrics: Arc<MetricsCollection>,
@@ -125,6 +126,7 @@ impl Datasource for RpcTransactionCrawler {
         );
 
         let task_processor = task_processor(
+            name,
             transaction_receiver,
             sender,
             filters,
@@ -345,6 +347,7 @@ fn transaction_fetcher(
 }
 
 fn task_processor(
+    name: String,
     transaction_receiver: Receiver<(Signature, EncodedConfirmedTransactionWithStatusMeta)>,
     sender: Sender<Update>,
     filters: Filters,
@@ -433,6 +436,7 @@ fn task_processor(
                         slot: fetched_transaction.slot,
                         block_time: fetched_transaction.block_time,
                         block_hash: None,
+                        source: name.clone(),
                     }));
 
 

--- a/examples/sharky-offers/src/main.rs
+++ b/examples/sharky-offers/src/main.rs
@@ -52,6 +52,7 @@ impl GpaBackfillDatasource {
 impl Datasource for GpaBackfillDatasource {
     async fn consume(
         &self,
+        name: String,
         sender: Sender<Update>,
         _cancellation_token: CancellationToken,
         _metrics: Arc<MetricsCollection>,
@@ -84,6 +85,7 @@ impl Datasource for GpaBackfillDatasource {
                 pubkey,
                 account,
                 slot,
+                source: name.clone(),
             })) {
                 log::error!("Failed to send account update: {:?}", e);
             }


### PR DESCRIPTION
Closes #255 

Unfortunately this is a breaking change, but I think it's flexible and also a good start for #265 

However I'm not sure about the name type and the cost of cloning String each time 

Unamed datasource are internally named with the reserved empty string `GENERIC_DATASOURCE_NAME`

example
```rs
pipeline
  .datasource(YellowstoneGrpcDatasource)
  .named_datasource(MyDatasource, "my_datasource1")
  .named_datasource(MyDatasource, "my_datasource2")
  .instruction_with_filters(PumpfunDecoder, MyProcessor, InstructionPipeFilters {
    sources: vec![GENERIC_DATASOURCE_NAME.into(), "my_datasource1".into()],
  })
  .accounts_with_filters(..., ..., AccountPipeFilters { sources: vec!["my_datasource2".into()] })
```

```rs
struct MyDataSource;

#[async_trait]
impl Datasource for MyDataSource {
    async fn consume(
        &self,
        name: String,
        sender: &tokio::sync::mpsc::UnboundedSender<Update>,
        cancellation_token: CancellationToken,
        _metrics: ...,
    ) -> CarbonResult<()> {
        // Implement data fetching and sending logic
        ...
        
    }

    fn update_types(&self) -> Vec<UpdateType> {
        vec![UpdateType::AccountUpdate, UpdateType::Transaction]
    }
}
```