### PR TITLE
feat: add block_hash field to transaction for fork detection (#277)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ target/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 .env
 *idl.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1491,6 +1491,7 @@ dependencies = [
  "log",
  "solana-client",
  "solana-pubkey",
+ "solana-sdk",
  "tokio",
  "tokio-util",
 ]

--- a/crates/core/src/datasource.rs
+++ b/crates/core/src/datasource.rs
@@ -33,6 +33,7 @@
 //! - Ensure implementations handle errors gracefully, especially when fetching
 //!   data and sending updates to the pipeline.
 
+use solana_program::hash::Hash;
 use {
     crate::{error::CarbonResult, metrics::MetricsCollection},
     async_trait::async_trait,
@@ -186,5 +187,5 @@ pub struct TransactionUpdate {
     pub is_vote: bool,
     pub slot: u64,
     pub block_time: Option<i64>,
-    pub block_hash: Option<String>,
+    pub block_hash: Option<Hash>,
 }

--- a/crates/core/src/datasource.rs
+++ b/crates/core/src/datasource.rs
@@ -175,6 +175,7 @@ pub struct AccountDeletion {
 /// - `is_vote`: A boolean indicating whether the transaction is a vote.
 /// - `slot`: The slot number in which the transaction was recorded.
 /// - `block_time`: The Unix timestamp of when the transaction was processed.
+/// - `block_hash`: Block hash that can be used to detect a fork.
 ///
 /// Note: The `block_time` field may not be returned in all scenarios.
 #[derive(Debug, Clone)]
@@ -185,4 +186,5 @@ pub struct TransactionUpdate {
     pub is_vote: bool,
     pub slot: u64,
     pub block_time: Option<i64>,
+    pub block_hash: Option<String>,
 }

--- a/crates/core/src/transaction.rs
+++ b/crates/core/src/transaction.rs
@@ -70,6 +70,7 @@ pub struct TransactionMetadata {
     pub meta: solana_transaction_status::TransactionStatusMeta,
     pub message: solana_program::message::VersionedMessage,
     pub block_time: Option<i64>,
+    pub block_hash: Option<String>,
 }
 
 impl Default for TransactionMetadata {
@@ -83,6 +84,7 @@ impl Default for TransactionMetadata {
                 solana_sdk::message::Message::default(),
             ),
             block_time: None,
+            block_hash: None
         }
     }
 }
@@ -122,6 +124,7 @@ impl TryFrom<crate::datasource::TransactionUpdate> for TransactionMetadata {
             meta: value.meta.clone(),
             message: value.transaction.message.clone(),
             block_time: value.block_time,
+            block_hash: value.block_hash,
         })
     }
 }

--- a/crates/core/src/transaction.rs
+++ b/crates/core/src/transaction.rs
@@ -29,6 +29,7 @@
 //!   instructions against the provided schema, only processing the data if it
 //!   conforms to the schema.
 
+use solana_program::hash::Hash;
 use {
     crate::{
         collection::InstructionDecoderCollection,
@@ -70,7 +71,7 @@ pub struct TransactionMetadata {
     pub meta: solana_transaction_status::TransactionStatusMeta,
     pub message: solana_program::message::VersionedMessage,
     pub block_time: Option<i64>,
-    pub block_hash: Option<String>,
+    pub block_hash: Option<Hash>,
 }
 
 impl Default for TransactionMetadata {

--- a/crates/core/src/transformers.rs
+++ b/crates/core/src/transformers.rs
@@ -728,6 +728,7 @@ mod tests {
             is_vote: false,
             slot: 123,
             block_time: Some(123),
+            block_hash: Some(Signature::new_unique().to_string()),
         };
         let transaction_metadata = transaction_update
             .clone()
@@ -1155,6 +1156,7 @@ mod tests {
             is_vote: false,
             slot: 123,
             block_time: Some(123),
+            block_hash: None,
         };
         let transaction_metadata = transaction_update
             .clone()

--- a/crates/core/src/transformers.rs
+++ b/crates/core/src/transformers.rs
@@ -728,7 +728,7 @@ mod tests {
             is_vote: false,
             slot: 123,
             block_time: Some(123),
-            block_hash: Some(Signature::new_unique().to_string()),
+            block_hash: Some("9bit9vXNX9HyHwL89aGDNmk3vbyAM96nvb6F4SaoM1CU".to_owned()),
         };
         let transaction_metadata = transaction_update
             .clone()

--- a/crates/core/src/transformers.rs
+++ b/crates/core/src/transformers.rs
@@ -728,7 +728,7 @@ mod tests {
             is_vote: false,
             slot: 123,
             block_time: Some(123),
-            block_hash: Some("9bit9vXNX9HyHwL89aGDNmk3vbyAM96nvb6F4SaoM1CU".to_owned()),
+            block_hash: Hash::from_str("9bit9vXNX9HyHwL89aGDNmk3vbyAM96nvb6F4SaoM1CU").ok(),
         };
         let transaction_metadata = transaction_update
             .clone()

--- a/datasources/helius-atlas-ws-datasource/src/lib.rs
+++ b/datasources/helius-atlas-ws-datasource/src/lib.rs
@@ -583,6 +583,7 @@ impl Datasource for HeliusWebsocket {
                                                 is_vote: config.filter.vote.is_some_and(|is_vote| is_vote),
                                                 slot: tx_event.slot,
                                                 block_time: None,
+                                                block_hash: None,
                                             }));
 
                                             metrics

--- a/datasources/jito-shredstream-grpc-datasource/src/lib.rs
+++ b/datasources/jito-shredstream-grpc-datasource/src/lib.rs
@@ -125,6 +125,7 @@ impl Datasource for JitoShredstreamGrpcClient {
                                     },
                                     slot: message.slot,
                                     block_time,
+                                    block_hash: None,
                                 }));
 
                                 if let Err(e) = sender.try_send(update) {

--- a/datasources/rpc-block-crawler-datasource/src/lib.rs
+++ b/datasources/rpc-block-crawler-datasource/src/lib.rs
@@ -268,6 +268,7 @@ fn task_processor(
                             log::error!("Error recording metric: {}", value)
                         });
                     let block_start_time = Instant::now();
+                    let block_hash = block.blockhash;
                     if let Some(transactions) = block.transactions {
                         for encoded_transaction_with_status_meta in transactions {
                             let start_time = std::time::Instant::now();
@@ -299,6 +300,7 @@ fn task_processor(
                                 is_vote: false,
                                 slot,
                                 block_time: block.block_time,
+                                block_hash: Some(block_hash.clone()),
                             }));
 
                             metrics

--- a/datasources/rpc-block-crawler-datasource/src/lib.rs
+++ b/datasources/rpc-block-crawler-datasource/src/lib.rs
@@ -1,4 +1,6 @@
+use std::str::FromStr;
 pub use solana_client::rpc_config::RpcBlockConfig;
+use solana_sdk::hash::Hash;
 use {
     async_trait::async_trait,
     carbon_core::{
@@ -268,7 +270,7 @@ fn task_processor(
                             log::error!("Error recording metric: {}", value)
                         });
                     let block_start_time = Instant::now();
-                    let block_hash = block.blockhash;
+                    let block_hash = Hash::from_str(&block.blockhash).ok();
                     if let Some(transactions) = block.transactions {
                         for encoded_transaction_with_status_meta in transactions {
                             let start_time = std::time::Instant::now();
@@ -300,7 +302,7 @@ fn task_processor(
                                 is_vote: false,
                                 slot,
                                 block_time: block.block_time,
-                                block_hash: Some(block_hash.clone()),
+                                block_hash,
                             }));
 
                             metrics

--- a/datasources/rpc-block-subscribe-datasource/Cargo.toml
+++ b/datasources/rpc-block-subscribe-datasource/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["encoding"]
 [dependencies]
 solana-client = { workspace = true }
 solana-pubkey = { workspace = true }
+solana-sdk = { workspace = true }
 
 carbon-core = { workspace = true }
 

--- a/datasources/rpc-block-subscribe-datasource/src/lib.rs
+++ b/datasources/rpc-block-subscribe-datasource/src/lib.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+use solana_sdk::hash::Hash;
 use {
     async_trait::async_trait,
     carbon_core::{
@@ -122,7 +124,7 @@ impl Datasource for RpcBlockSubscribe {
 
                                 if let Some(block) = tx_event.value.block {
                                     let block_start_time = std::time::Instant::now();
-                                    let block_hash = block.blockhash;
+                                    let block_hash = Hash::from_str(&block.blockhash).ok();
                                     if let Some(transactions) = block.transactions {
                                         for encoded_transaction_with_status_meta in transactions {
                                             let start_time = std::time::Instant::now();
@@ -154,7 +156,7 @@ impl Datasource for RpcBlockSubscribe {
                                                 is_vote: false,
                                                 slot,
                                                 block_time: block.block_time,
-                                                block_hash: Some(block_hash.clone()),
+                                                block_hash,
                                             }));
 
                                             metrics

--- a/datasources/rpc-block-subscribe-datasource/src/lib.rs
+++ b/datasources/rpc-block-subscribe-datasource/src/lib.rs
@@ -122,6 +122,7 @@ impl Datasource for RpcBlockSubscribe {
 
                                 if let Some(block) = tx_event.value.block {
                                     let block_start_time = std::time::Instant::now();
+                                    let block_hash = block.blockhash;
                                     if let Some(transactions) = block.transactions {
                                         for encoded_transaction_with_status_meta in transactions {
                                             let start_time = std::time::Instant::now();
@@ -153,6 +154,7 @@ impl Datasource for RpcBlockSubscribe {
                                                 is_vote: false,
                                                 slot,
                                                 block_time: block.block_time,
+                                                block_hash: Some(block_hash.clone()),
                                             }));
 
                                             metrics

--- a/datasources/rpc-transaction-crawler-datasource/src/lib.rs
+++ b/datasources/rpc-transaction-crawler-datasource/src/lib.rs
@@ -432,6 +432,7 @@ fn task_processor(
                         is_vote: false,
                         slot: fetched_transaction.slot,
                         block_time: fetched_transaction.block_time,
+                        block_hash: None,
                     }));
 
 

--- a/datasources/yellowstone-grpc-datasource/src/lib.rs
+++ b/datasources/yellowstone-grpc-datasource/src/lib.rs
@@ -232,6 +232,7 @@ impl Datasource for YellowstoneGrpcGeyserClient {
                                                         is_vote: transaction_info.is_vote,
                                                         slot: transaction_update.slot,
                                                         block_time: None,
+                                                        block_hash: None,
                                                     }));
                                                     if let Err(e) = sender.try_send(update) {
                                                         log::error!("Failed to send transaction update with signature {:?} at slot {}: {:?}", signature, transaction_update.slot, e);


### PR DESCRIPTION
- Added `block_hash` field to the `TransactionUpdate` entity to track forks.

Issue: https://github.com/sevenlabs-hq/carbon/issues/277