### PR TITLE
feat: Add block-only subscription (no transactions)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,6 +843,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-finality-alerts-carbon-example"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "carbon-core",
+ "carbon-log-metrics",
+ "carbon-rpc-block-subscribe-datasource",
+ "dotenv",
+ "env_logger 0.11.8",
+ "log",
+ "solana-client",
+ "solana-sdk",
+ "solana-transaction-status",
+ "tokio",
+]
+
+[[package]]
 name = "borsh"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1611,12 +1628,11 @@ version = "0.8.0"
 dependencies = [
  "async-trait",
  "carbon-core",
- "env_logger 0.11.8",
  "futures",
  "log",
  "solana-client",
- "solana-pubkey",
  "solana-sdk",
+ "solana-transaction-status",
  "tokio",
  "tokio-util",
 ]

--- a/crates/core/src/block_details.rs
+++ b/crates/core/src/block_details.rs
@@ -1,0 +1,129 @@
+use crate::account_deletion::{AccountDeletionPipe, AccountDeletionPipes};
+use crate::datasource::{AccountDeletion, BlockDetails};
+use crate::error::CarbonResult;
+use crate::metrics::MetricsCollection;
+use crate::processor::Processor;
+use async_trait::async_trait;
+use std::sync::Arc;
+
+/// A pipe for processing block details using a defined processor.
+///
+/// The `BlockDetailsPipe` processes updates related to block metadata, such as
+/// slot, block hash, and rewards. It uses a `Processor` to handle the block
+/// details and perform the necessary operations.
+///
+/// ## Fields
+///
+/// - `processor`: A `Processor` that processes block details updates.
+pub struct BlockDetailsPipe {
+    pub processor: Box<dyn Processor<InputType = BlockDetails> + Send + Sync>,
+}
+
+
+/// A trait for handling block details updates in the pipeline.
+///
+/// The `BlockDetailsPipes` trait defines an asynchronous `run` method, which
+/// is responsible for processing a `BlockDetails` event. Implementing this
+/// trait allows you to create custom block details handling within the
+/// pipeline, which can be extended to include metrics tracking or other
+/// custom behaviors.
+///
+/// ## Functionality
+///
+/// The `run` method takes a `BlockDetails` event and a list of `Metrics` to
+/// track the processing operation. The method is asynchronous, allowing for
+/// non-blocking operations, and is expected to return a `CarbonResult<()>`,
+/// which indicates success or failure.
+///
+/// # Syntax
+///
+/// Implementations of `BlockDetailsPipes` should focus on handling block
+/// details updates and integrating with metrics as needed.
+///
+/// # Example
+///
+/// ```ignore
+/// use carbon_core::metrics::MetricsCollection;
+/// use std::sync::Arc;
+/// use carbon_core::error::CarbonResult;
+/// use carbon_core::datasource::BlockDetails;
+/// use carbon_core::block_details::BlockDetailsPipe;
+/// use async_trait::async_trait;
+///
+/// struct MyBlockDetailsPipe;
+///
+/// #[async_trait]
+/// impl BlockDetailsPipes for BlockDetailsPipe {
+///     async fn run(
+///         &mut self,
+///         block_details: BlockDetails,
+///         metrics: Arc<MetricsCollection>,
+///     ) -> CarbonResult<()> {
+///         // Custom processing logic for the block details event
+///         Ok(())
+///     }
+/// }
+/// ```
+///
+/// # Parameters
+///
+/// - `block_details`: A `BlockDetails` instance representing the block details
+///   update event.
+/// - `metrics`: A vector of `Metrics` objects for monitoring and reporting
+///   purposes.
+///
+/// # Returns
+///
+/// Returns a `CarbonResult<()>`, which will be `Ok(())` if processing is
+/// successful, or an error if there was an issue with the processing logic.
+///
+/// # Notes
+///
+/// - This trait is asynchronous and requires the `async_trait` crate for
+///   `async` methods.
+/// - Ensure that `BlockDetailsPipe` is configured with a processor capable
+///   of handling block details updates, as this is its primary responsibility
+///   within the pipeline.
+#[async_trait]
+pub trait BlockDetailsPipes: Send + Sync {
+    /// Processes a block details event and tracks the operation with
+    /// metrics.
+    ///
+    /// This asynchronous method allows for non-blocking processing of block
+    /// details events, enabling integration with custom logic and metrics
+    /// tracking.
+    ///
+    /// # Parameters
+    ///
+    /// - `block_details`: The block details event to process.
+    /// - `metrics`: A list of `Metrics` implementations for tracking and
+    ///   reporting metrics.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `CarbonResult<()>`, which is `Ok` on success, or an error if
+    /// processing fails.
+    async fn run(
+        &mut self,
+        block_details: BlockDetails,
+        metrics: Arc<MetricsCollection>,
+    ) -> CarbonResult<()>;
+}
+
+#[async_trait]
+impl BlockDetailsPipes for BlockDetailsPipe {
+    async fn run(
+        &mut self,
+        block_details: BlockDetails,
+        metrics: Arc<MetricsCollection>,
+    ) -> CarbonResult<()> {
+        log::trace!(
+            "Block details::run(block_details: {:?}, metrics)",
+            block_details,
+        );
+
+        self.processor.process(block_details, metrics).await?;
+
+        Ok(())
+    }
+}

--- a/crates/core/src/datasource.rs
+++ b/crates/core/src/datasource.rs
@@ -34,6 +34,7 @@
 //!   data and sending updates to the pipeline.
 
 use solana_program::hash::Hash;
+use solana_transaction_status::Rewards;
 use {
     crate::{error::CarbonResult, metrics::MetricsCollection},
     async_trait::async_trait,
@@ -121,6 +122,7 @@ pub enum Update {
     Account(AccountUpdate),
     Transaction(Box<TransactionUpdate>),
     AccountDeletion(AccountDeletion),
+    BlockDetails(BlockDetails)
 }
 
 /// Enumerates the types of updates a datasource can provide.
@@ -152,6 +154,29 @@ pub struct AccountUpdate {
     pub pubkey: Pubkey,
     pub account: Account,
     pub slot: u64,
+}
+
+/// Represents the details of a Solana block, including its slot, hashes, rewards, and timing information.
+///
+/// The `BlockDetails` struct encapsulates the essential information for a block, 
+/// providing details about its slot, blockhashes, rewards, and other metadata.
+///
+/// - `slot`: The slot number in which this block was recorded.
+/// - `previous_block_hash`: The hash of the previous block in the blockchain.
+/// - `block_hash`: The hash of the current block.
+/// - `rewards`: Optional rewards information associated with the block, such as staking rewards.
+/// - `num_reward_partitions`: Optional number of reward partitions in the block.
+/// - `block_time`: Optional Unix timestamp indicating when the block was processed.
+/// - `block_height`: Optional height of the block in the blockchain.#[derive(Debug, Clone)]
+#[derive(Debug, Clone)]
+pub struct BlockDetails {
+    pub slot: u64,
+    pub block_hash: Option<Hash>,
+    pub previous_block_hash: Option<Hash>,
+    pub rewards: Option<Rewards>,
+    pub num_reward_partitions: Option<u64>,
+    pub block_time: Option<i64>,
+    pub block_height: Option<u64>,
 }
 
 /// Represents the deletion of a Solana account, containing the account's public

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -125,6 +125,8 @@ pub mod processor;
 pub mod schema;
 pub mod transaction;
 pub mod transformers;
+mod block_details;
+
 pub use borsh;
 #[cfg(feature = "macros")]
 pub use carbon_macros::*;

--- a/datasources/rpc-block-subscribe-datasource/Cargo.toml
+++ b/datasources/rpc-block-subscribe-datasource/Cargo.toml
@@ -11,13 +11,12 @@ categories = ["encoding"]
 
 [dependencies]
 solana-client = { workspace = true }
-solana-pubkey = { workspace = true }
 solana-sdk = { workspace = true }
+solana-transaction-status = { workspace = true }
 
 carbon-core = { workspace = true }
 
 async-trait = { workspace = true }
-env_logger = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/datasources/rpc-block-subscribe-datasource/src/lib.rs
+++ b/datasources/rpc-block-subscribe-datasource/src/lib.rs
@@ -1,5 +1,6 @@
 use std::str::FromStr;
 use solana_sdk::hash::Hash;
+use solana_transaction_status::TransactionDetails;
 use {
     async_trait::async_trait,
     carbon_core::{
@@ -19,6 +20,7 @@ use {
     tokio::sync::mpsc::Sender,
     tokio_util::sync::CancellationToken,
 };
+use carbon_core::datasource::BlockDetails;
 
 const MAX_RECONNECTION_ATTEMPTS: u32 = 10;
 const RECONNECTION_DELAY_MS: u64 = 3000;
@@ -125,6 +127,23 @@ impl Datasource for RpcBlockSubscribe {
                                 if let Some(block) = tx_event.value.block {
                                     let block_start_time = std::time::Instant::now();
                                     let block_hash = Hash::from_str(&block.blockhash).ok();
+                                    let previous_block_hash = Hash::from_str(&block.previous_blockhash).ok();
+                                    
+                                    let block_deteils = Update::BlockDetails( BlockDetails {
+                                                slot,
+                                                block_hash,
+                                                previous_block_hash,
+                                                rewards: block.rewards,
+                                                num_reward_partitions: block.num_reward_partitions,
+                                                block_time: block.block_time,
+                                                block_height: block.block_height,
+                                    });
+                                    
+                                    if let Err(err) = sender_clone.try_send(block_deteils) {
+                                        log::error!("Error sending block details: {:?}", err);
+                                        break;
+                                    }
+                                    
                                     if let Some(transactions) = block.transactions {
                                         for encoded_transaction_with_status_meta in transactions {
                                             let start_time = std::time::Instant::now();
@@ -177,7 +196,7 @@ impl Datasource for RpcBlockSubscribe {
                                             }
                                         }
                                     }
-
+                                    
                                     metrics
                                         .record_histogram(
                                             "block_subscribe_block_process_time_nanoseconds",

--- a/examples/block-finality-alerts/Cargo.toml
+++ b/examples/block-finality-alerts/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "block-finality-alerts-carbon-example"
+version = "0.1.0"
+edition = { workspace = true }
+
+[dependencies]
+carbon-core = { workspace = true }
+carbon-log-metrics = { workspace = true }
+carbon-rpc-block-subscribe-datasource = { workspace = true }
+solana-client = { workspace = true }
+solana-sdk = { workspace = true }
+solana-transaction-status = { workspace = true }
+
+async-trait = { workspace = true }
+dotenv = { workspace = true }
+env_logger = { workspace = true }
+log = { workspace = true }
+tokio = { workspace = true, features = ["full"] }

--- a/examples/block-finality-alerts/README.md
+++ b/examples/block-finality-alerts/README.md
@@ -1,0 +1,44 @@
+# Carbon Pipeline Example
+
+This project demonstrates how to set up and run a Carbon pipeline that processes Solana blocks. It uses the `RpcBlockSubscribe` to fetch Solana final blocks and processes these blocks.
+
+## Setup Instructions
+
+### Step 1: Clone the Repository
+
+To get started, clone the repository:
+
+```sh
+git clone git@github.com:sevenlabs-hq/carbon.git
+cd examples/block-finality-alerts
+```
+
+### Step 2: Set Environment Variables
+
+Create a `.env` file in the root of your project and set the following environment variables:
+
+```env
+RPC_WS_URL=...
+```
+
+This `RPC_WS_URL` should point to the RPC Websocket endpoint you want to use for Solana block subscribing.
+
+### Step 3: Build the Project
+
+To compile the project, run the following command:
+
+```sh
+cargo build --release
+```
+
+### Step 4: Run the Pipeline
+
+After building the project, you can run the pipeline using:
+
+```sh
+cargo run --release
+```
+
+## Metrics
+
+The example includes a basic metrics setup using `LogMetrics`. You can extend this by implementing your own metrics and passing them to the pipeline.

--- a/examples/block-finality-alerts/src/main.rs
+++ b/examples/block-finality-alerts/src/main.rs
@@ -1,0 +1,68 @@
+use carbon_core::datasource::BlockDetails;
+use solana_sdk::commitment_config::CommitmentConfig;
+use solana_transaction_status::TransactionDetails;
+use {
+    async_trait::async_trait,
+    carbon_core::{
+        error::CarbonResult,
+        instruction::{DecodedInstruction, InstructionMetadata, NestedInstructions},
+        metrics::MetricsCollection,
+        processor::Processor,
+    },
+    carbon_log_metrics::LogMetrics,
+    carbon_rpc_block_subscribe_datasource::{Filters, RpcBlockSubscribe},
+    solana_client::rpc_config::{RpcBlockSubscribeConfig, RpcBlockSubscribeFilter},
+    std::{env, sync::Arc},
+};
+
+#[tokio::main]
+pub async fn main() -> CarbonResult<()> {
+    env_logger::init();
+    dotenv::dotenv().ok();
+
+    let filters = Filters::new(
+        RpcBlockSubscribeFilter::All,
+        Some(RpcBlockSubscribeConfig {
+            commitment: Some(CommitmentConfig::finalized()),
+            transaction_details: Some(TransactionDetails::None),
+            max_supported_transaction_version: Some(0),
+            ..RpcBlockSubscribeConfig::default()
+        }),
+    );
+
+    let rpc_ws_url =
+        env::var("RPC_WS_URL").unwrap_or("wss://api.mainnet-beta.solana.com/".to_string());
+
+    log::info!("Starting with RPC: {}", rpc_ws_url);
+    let block_subscribe = RpcBlockSubscribe::new(rpc_ws_url, filters);
+
+    carbon_core::pipeline::Pipeline::builder()
+        .datasource(block_subscribe)
+        .metrics(Arc::new(LogMetrics::new()))
+        .metrics_flush_interval(3)
+        .block_details(BlockProcessor)
+        .shutdown_strategy(carbon_core::pipeline::ShutdownStrategy::Immediate)
+        .build()?
+        .run()
+        .await?;
+
+    Ok(())
+}
+
+pub struct BlockProcessor;
+
+#[async_trait]
+impl Processor for BlockProcessor {
+    type InputType = BlockDetails;
+
+    async fn process(
+        &mut self,
+        block_details: Self::InputType,
+        _metrics: Arc<MetricsCollection>,
+    ) -> CarbonResult<()> {
+
+        log::info!("Final block: {:?}", &block_details);
+      
+        Ok(())
+    }
+}


### PR DESCRIPTION
- Extend the current block subscription functionality to allow receiving only block information without transactions.
- Added an example demonstrating how to use the new block subscription functionality.