### PR TITLE
fix: export log crate used by proc macro

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -132,3 +132,6 @@ pub use borsh;
 pub use carbon_macros::*;
 #[cfg(feature = "macros")]
 pub use carbon_proc_macros::*;
+#[cfg(feature = "macros")]
+#[doc(hidden)]
+pub use log;

--- a/crates/proc-macros/src/lib.rs
+++ b/crates/proc-macros/src/lib.rs
@@ -151,7 +151,7 @@ pub fn carbon_deserialize_derive(input_token_stream: TokenStream) -> TokenStream
                  match carbon_core::borsh::BorshDeserialize::deserialize(&mut rest) {
                     Ok(res) => {
                         if !rest.is_empty() {
-                            log::warn!(
+                            carbon_core::log::warn!(
                                 "Not all bytes were read when deserializing {}: {} bytes remaining",
                                 stringify!(#name),
                                 rest.len(),


### PR DESCRIPTION
`log` crate need to be exported from carbon_core to be used by proc macros

```
4 |     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
  |     ^^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `log`
```