### PR TITLE
Add addLiquidityByStrategy2 ix to meteora-dlmm-decoder

### DIFF
--- a/decoders/meteora-dlmm-decoder/src/instructions/add_liquidity_by_strategy2.rs
+++ b/decoders/meteora-dlmm-decoder/src/instructions/add_liquidity_by_strategy2.rs
@@ -1,0 +1,62 @@
+use {
+    super::{super::types::*, add_liquidity_by_strategy::AddLiquidityByStrategyInstructionAccounts},
+    carbon_core::{borsh, CarbonDeserialize},
+};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0x03dd95da6f8d76d5")]
+pub struct AddLiquidityByStrategy2 {
+    pub liquidity_parameter: LiquidityParameterByStrategy,
+}
+
+pub struct AddLiquidityByStrategy2InstructionAccounts {
+    pub position: solana_pubkey::Pubkey,
+    pub lb_pair: solana_pubkey::Pubkey,
+    pub bin_array_bitmap_extension: solana_pubkey::Pubkey,
+    pub user_token_x: solana_pubkey::Pubkey,
+    pub user_token_y: solana_pubkey::Pubkey,
+    pub reserve_x: solana_pubkey::Pubkey,
+    pub reserve_y: solana_pubkey::Pubkey,
+    pub token_x_mint: solana_pubkey::Pubkey,
+    pub token_y_mint: solana_pubkey::Pubkey,
+    pub sender: solana_pubkey::Pubkey,
+    pub token_x_program: solana_pubkey::Pubkey,
+    pub token_y_program: solana_pubkey::Pubkey,
+    pub event_authority: solana_pubkey::Pubkey,
+    pub program: solana_pubkey::Pubkey,
+    pub remaining_accounts: Vec<solana_instruction::AccountMeta>,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for AddLiquidityByStrategy2 {
+    type ArrangedAccounts = AddLiquidityByStrategy2InstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let [position, lb_pair, bin_array_bitmap_extension, user_token_x, user_token_y, reserve_x, reserve_y, token_x_mint, token_y_mint, sender, token_x_program, token_y_program, event_authority, program, remaining_accounts @ ..] =
+            accounts
+        else {
+            return None;
+        };
+
+        Some(AddLiquidityByStrategy2InstructionAccounts {
+            position: position.pubkey,
+            lb_pair: lb_pair.pubkey,
+            bin_array_bitmap_extension: bin_array_bitmap_extension.pubkey,
+            user_token_x: user_token_x.pubkey,
+            user_token_y: user_token_y.pubkey,
+            reserve_x: reserve_x.pubkey,
+            reserve_y: reserve_y.pubkey,
+            token_x_mint: token_x_mint.pubkey,
+            token_y_mint: token_y_mint.pubkey,
+            sender: sender.pubkey,
+            token_x_program: token_x_program.pubkey,
+            token_y_program: token_y_program.pubkey,
+            event_authority: event_authority.pubkey,
+            program: program.pubkey,
+            remaining_accounts: remaining_accounts.to_vec(),
+        })
+    }
+}

--- a/decoders/meteora-dlmm-decoder/src/instructions/mod.rs
+++ b/decoders/meteora-dlmm-decoder/src/instructions/mod.rs
@@ -3,6 +3,7 @@ use crate::PROGRAM_ID;
 use super::MeteoraDlmmDecoder;
 pub mod add_liquidity;
 pub mod add_liquidity_by_strategy;
+pub mod add_liquidity_by_strategy2;
 pub mod add_liquidity_by_strategy_one_side;
 pub mod add_liquidity_by_weight;
 pub mod add_liquidity_event;
@@ -86,6 +87,7 @@ pub enum MeteoraDlmmInstruction {
     AddLiquidity(add_liquidity::AddLiquidity),
     AddLiquidityByWeight(add_liquidity_by_weight::AddLiquidityByWeight),
     AddLiquidityByStrategy(add_liquidity_by_strategy::AddLiquidityByStrategy),
+    AddLiquidityByStrategy2(add_liquidity_by_strategy2::AddLiquidityByStrategy2),
     AddLiquidityByStrategyOneSide(
         add_liquidity_by_strategy_one_side::AddLiquidityByStrategyOneSide,
     ),
@@ -165,6 +167,7 @@ impl carbon_core::instruction::InstructionDecoder<'_> for MeteoraDlmmDecoder {
             MeteoraDlmmInstruction::AddLiquidity => add_liquidity::AddLiquidity,
             MeteoraDlmmInstruction::AddLiquidityByWeight => add_liquidity_by_weight::AddLiquidityByWeight,
             MeteoraDlmmInstruction::AddLiquidityByStrategy => add_liquidity_by_strategy::AddLiquidityByStrategy,
+            MeteoraDlmmInstruction::AddLiquidityByStrategy2 => add_liquidity_by_strategy2::AddLiquidityByStrategy2,
             MeteoraDlmmInstruction::AddLiquidityByStrategyOneSide => add_liquidity_by_strategy_one_side::AddLiquidityByStrategyOneSide,
             MeteoraDlmmInstruction::AddLiquidityOneSide => add_liquidity_one_side::AddLiquidityOneSide,
             MeteoraDlmmInstruction::RemoveLiquidity => remove_liquidity::RemoveLiquidity,


### PR DESCRIPTION
Add support for `addLiquidityByStrategy2` instruction to `meteora-dlmm-decoder`.
[Example](https://solscan.io/tx/CTgcxnPupHagDBUpwQfHaZ7GFuWfDGie5Vx7CFc29vfMvwz2H3xGxYACjMz5MN9nP8yyxy84jE6tokuxsJw82bV) of tx with this instruction.