### PR TITLE
chore: Remove need for solana-signature rand feature

### DIFF
--- a/crates/core/src/transaction.rs
+++ b/crates/core/src/transaction.rs
@@ -63,7 +63,7 @@ use {
 /// - `block_time`: The Unix timestamp of when the transaction was processed.
 ///
 /// Note: The `block_time` field may not be returned in all scenarios.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct TransactionMetadata {
     pub slot: u64,
     pub signature: Signature,
@@ -74,19 +74,6 @@ pub struct TransactionMetadata {
     pub block_hash: Option<Hash>,
 }
 
-impl Default for TransactionMetadata {
-    fn default() -> Self {
-        Self {
-            slot: 0,
-            signature: Signature::new_unique(),
-            fee_payer: Pubkey::new_unique(),
-            meta: solana_transaction_status::TransactionStatusMeta::default(),
-            message: solana_message::VersionedMessage::Legacy(solana_message::Message::default()),
-            block_time: None,
-            block_hash: None,
-        }
-    }
-}
 /// Tries convert transaction update into the metadata.
 ///
 /// This function retrieves core metadata such as the transaction's slot,


### PR DESCRIPTION
when using carbon-core build might fail because the rand feature of solana-signature and solana-pubkey crates are not explicitly enabled.

<img width="666" alt="Screenshot 2025-05-21 at 5 03 00 pm" src="https://github.com/user-attachments/assets/ba10af09-6b10-4b93-a7b4-0bb52a8b5311" />

I don't think default should call new_unique()