### PR TITLE
Add Data Sink Pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-postgres-datasink"
-version = "0.1.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4207,6 +4207,7 @@ dependencies = [
  "carbon-core",
  "carbon-log-metrics",
  "carbon-meteora-dlmm-decoder",
+ "carbon-postgres-datasink",
  "carbon-rpc-transaction-crawler-datasource",
  "dotenv",
  "env_logger 0.11.8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1576,6 +1576,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "carbon-postgres-datasink"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bincode",
+ "carbon-core",
+ "carbon-postgres-client",
+ "serde_json",
+ "solana-transaction-status",
+ "sqlx",
+ "tokio",
+]
+
+[[package]]
 name = "carbon-proc-macros"
 version = "0.8.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/*", "datasources/*", "decoders/*", "examples/*", "metrics/*"]
+members = ["crates/*", "datasources/*", "datasinks/*", "decoders/*", "examples/*", "metrics/*"]
 resolver = "2"
 
 [workspace.package]
@@ -27,6 +27,9 @@ carbon-rpc-block-subscribe-datasource = { path = "datasources/rpc-block-subscrib
 carbon-rpc-program-subscribe-datasource = { path = "datasources/rpc-program-subscribe-datasource", version = "0.8.1" }
 carbon-rpc-transaction-crawler-datasource = { path = "datasources/rpc-transaction-crawler-datasource", version = "0.8.1" }
 carbon-yellowstone-grpc-datasource = { path = "datasources/yellowstone-grpc-datasource", version = "0.8.1" }
+
+# datasinks
+carbon-postgres-datasink = { path = "datasinks/postgres-datasink", version = "0.8.1" }
 
 # metrics
 carbon-log-metrics = { path = "metrics/log-metrics", version = "0.8.1" }

--- a/crates/core/src/datasink.rs
+++ b/crates/core/src/datasink.rs
@@ -1,0 +1,16 @@
+use async_trait::async_trait;
+
+use crate::datasource::{AccountUpdate, TransactionUpdate};
+
+#[async_trait]
+pub trait DataSink: Send + Sync {
+    async fn capture_account(&self, account_update: AccountUpdate);
+    async fn capture_transaction(&self, transaction_update: TransactionUpdate);
+    async fn flush_accounts(&self);
+    async fn flush_transactions(&self);
+}
+
+#[async_trait]
+pub trait PeriodicFlush: Send + Sync {
+    async fn start_periodic_flush(&self);
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -22,6 +22,10 @@
 //! - **[`collection`]**: Defines collections for instruction decoding, allowing
 //!   for customized instruction parsers that handle specific instruction sets.
 //!
+//! - **[`datasink`]**: Provides data sink capabilities, enabling the
+//!   integration of external data sinks into the pipeline. Supports
+//!   Solana-specific data structures.
+//!
 //! - **[`datasource`]**: Provides data ingestion capabilities, enabling the
 //!   integration of external data sources into the pipeline. Supports
 //!   Solana-specific data structures.
@@ -116,6 +120,7 @@ pub mod account;
 pub mod account_deletion;
 mod block_details;
 pub mod collection;
+pub mod datasink;
 pub mod datasource;
 pub mod deserialize;
 pub mod error;

--- a/datasinks/postgres-datasink/Cargo.toml
+++ b/datasinks/postgres-datasink/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "carbon-postgres-datasink"
+description = "Carbon Postgres Datasink"
+license = { workspace = true }
+version = "0.1.0"
+edition = { workspace = true }
+readme = "README.md"
+repository = { workspace = true }
+keywords = ["solana", "indexer", "postgres", "datasink"]
+categories = ["database-implementations"]
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+async-trait = { workspace = true }
+base64 = { workspace = true }
+bincode = { workspace = true }
+carbon-core = { workspace = true }
+carbon-postgres-client = { workspace = true }
+serde_json = { workspace = true }
+solana-transaction-status = { workspace = true }
+sqlx = { workspace = true }
+tokio = { workspace = true, features = ["full"] }

--- a/datasinks/postgres-datasink/Cargo.toml
+++ b/datasinks/postgres-datasink/Cargo.toml
@@ -2,7 +2,7 @@
 name = "carbon-postgres-datasink"
 description = "Carbon Postgres Datasink"
 license = { workspace = true }
-version = "0.1.0"
+version = "0.8.1"
 edition = { workspace = true }
 readme = "README.md"
 repository = { workspace = true }

--- a/datasinks/postgres-datasink/src/lib.rs
+++ b/datasinks/postgres-datasink/src/lib.rs
@@ -1,11 +1,10 @@
 use async_trait::async_trait;
-use base64;
-use bincode;
+use base64::Engine as _;
 use carbon_core::datasink::{DataSink, PeriodicFlush};
 use carbon_core::datasource::{AccountUpdate, TransactionUpdate};
 use carbon_postgres_client::PgClient;
 use serde_json;
-use solana_transaction_status::{UiTransactionEncoding, UiTransactionStatusMeta};
+use solana_transaction_status::UiTransactionStatusMeta;
 use std::collections::VecDeque;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -149,7 +148,7 @@ impl DataSink for PostgresWriter {
 
             transactions.push((
                 update.signature.as_ref().to_vec(),
-                base64::encode(tx_bytes),
+                base64::engine::general_purpose::STANDARD.encode(tx_bytes),
                 meta_json,
                 update.is_vote,
                 update.slot as i64,

--- a/datasinks/postgres-datasink/src/lib.rs
+++ b/datasinks/postgres-datasink/src/lib.rs
@@ -1,0 +1,229 @@
+use async_trait::async_trait;
+use base64;
+use bincode;
+use carbon_core::datasink::{DataSink, PeriodicFlush};
+use carbon_core::datasource::{AccountUpdate, TransactionUpdate};
+use carbon_postgres_client::PgClient;
+use serde_json;
+use solana_transaction_status::{UiTransactionEncoding, UiTransactionStatusMeta};
+use std::collections::VecDeque;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tokio::time::{interval, Duration};
+
+// Schema for raw data tables
+/*
+CREATE TABLE carbon_raw_account (
+    id SERIAL PRIMARY KEY,
+    pubkey BYTEA NOT NULL,
+    owner BYTEA NOT NULL,
+    lamports BIGINT NOT NULL,
+    data BYTEA NOT NULL,
+    executable BOOLEAN NOT NULL,
+    rent_epoch BIGINT NOT NULL,
+    slot BIGINT NOT NULL,
+    processed_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE carbon_raw_transaction (
+    id SERIAL PRIMARY KEY,
+    signature BYTEA NOT NULL,
+    transaction TEXT NOT NULL,  -- Base64 encoded raw transaction
+    meta TEXT NOT NULL,         -- JSON encoded transaction metadata
+    is_vote BOOLEAN NOT NULL,
+    slot BIGINT NOT NULL,
+    block_time BIGINT,
+    block_hash BYTEA,
+    processed_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+*/
+
+pub struct PostgresWriter {
+    client: Arc<PgClient>,
+    account_buffer: Arc<Mutex<VecDeque<AccountUpdate>>>,
+    transaction_buffer: Arc<Mutex<VecDeque<TransactionUpdate>>>,
+    max_buffer_size: usize,
+    flush_interval: Duration,
+}
+
+impl PostgresWriter {
+    pub async fn new(
+        connection_string: &str,
+        max_buffer_size: usize,
+        flush_interval_secs: u64,
+    ) -> Result<Self, sqlx::Error> {
+        let client = PgClient::new(connection_string, 1, 10).await?;
+
+        Ok(PostgresWriter {
+            client: Arc::new(client),
+            account_buffer: Arc::new(Mutex::new(VecDeque::new())),
+            transaction_buffer: Arc::new(Mutex::new(VecDeque::new())),
+            max_buffer_size,
+            flush_interval: Duration::from_secs(flush_interval_secs),
+        })
+    }
+}
+
+#[async_trait]
+impl DataSink for PostgresWriter {
+    async fn capture_account(&self, account_update: AccountUpdate) {
+        let mut buffer = self.account_buffer.lock().await;
+        buffer.push_back(account_update);
+        if buffer.len() >= self.max_buffer_size {
+            self.flush_accounts().await;
+        }
+    }
+
+    async fn capture_transaction(&self, transaction_update: TransactionUpdate) {
+        let mut buffer = self.transaction_buffer.lock().await;
+        buffer.push_back(transaction_update);
+        if buffer.len() >= self.max_buffer_size {
+            self.flush_transactions().await;
+        }
+    }
+
+    async fn flush_accounts(&self) {
+        let mut buffer = self.account_buffer.lock().await;
+        if buffer.is_empty() {
+            return;
+        }
+
+        let mut accounts = Vec::new();
+        while let Some(update) = buffer.pop_front() {
+            accounts.push((
+                update.pubkey.to_bytes().to_vec(),
+                update.account.owner.to_bytes().to_vec(),
+                update.account.lamports as i64,
+                update.account.data,
+                update.account.executable,
+                update.account.rent_epoch as i64,
+                update.slot as i64,
+            ));
+        }
+
+        if !accounts.is_empty() {
+            let mut tx = self
+                .client
+                .pool
+                .begin()
+                .await
+                .expect("Failed to begin transaction");
+
+            for account in accounts {
+                sqlx::query(
+                    "INSERT INTO carbon_raw_account 
+                    (pubkey, owner, lamports, data, executable, rent_epoch, slot) 
+                    VALUES ($1, $2, $3, $4, $5, $6, $7)",
+                )
+                .bind(account.0)
+                .bind(account.1)
+                .bind(account.2)
+                .bind(account.3)
+                .bind(account.4)
+                .bind(account.5)
+                .bind(account.6)
+                .execute(&mut *tx)
+                .await
+                .expect("Failed to insert account");
+            }
+
+            tx.commit().await.expect("Failed to commit transaction");
+        }
+    }
+
+    async fn flush_transactions(&self) {
+        let mut buffer = self.transaction_buffer.lock().await;
+        if buffer.is_empty() {
+            return;
+        }
+
+        let mut transactions = Vec::new();
+        while let Some(update) = buffer.pop_front() {
+            // Convert transaction to base64 encoded string
+            let tx_bytes = update.transaction.message.serialize();
+
+            // Convert metadata to JSON string
+            let meta_json =
+                serde_json::to_string(&UiTransactionStatusMeta::from(update.meta.clone()))
+                    .unwrap_or_default();
+
+            transactions.push((
+                update.signature.as_ref().to_vec(),
+                base64::encode(tx_bytes),
+                meta_json,
+                update.is_vote,
+                update.slot as i64,
+                update.block_time.map(|t| t as i64),
+                update.block_hash.map(|h| h.to_bytes().to_vec()),
+            ));
+        }
+
+        if !transactions.is_empty() {
+            let mut tx = self
+                .client
+                .pool
+                .begin()
+                .await
+                .expect("Failed to begin transaction");
+
+            for tx_data in transactions {
+                sqlx::query(
+                    "INSERT INTO carbon_raw_transaction 
+                    (signature, transaction, meta, is_vote, slot, block_time, block_hash) 
+                    VALUES ($1, $2, $3, $4, $5, $6, $7)",
+                )
+                .bind(tx_data.0)
+                .bind(tx_data.1)
+                .bind(tx_data.2)
+                .bind(tx_data.3)
+                .bind(tx_data.4)
+                .bind(tx_data.5)
+                .bind(tx_data.6)
+                .execute(&mut *tx)
+                .await
+                .expect("Failed to insert transaction");
+            }
+
+            tx.commit().await.expect("Failed to commit transaction");
+        }
+    }
+}
+
+#[async_trait]
+impl PeriodicFlush for PostgresWriter {
+    async fn start_periodic_flush(&self) {
+        let accounts_self = self.clone();
+        let transactions_self = self.clone();
+
+        // Spawn periodic flush for accounts
+        tokio::spawn(async move {
+            let mut interval = interval(accounts_self.flush_interval);
+            loop {
+                interval.tick().await;
+                accounts_self.flush_accounts().await;
+            }
+        });
+
+        // Spawn periodic flush for transactions
+        tokio::spawn(async move {
+            let mut interval = interval(transactions_self.flush_interval);
+            loop {
+                interval.tick().await;
+                transactions_self.flush_transactions().await;
+            }
+        });
+    }
+}
+
+// To allow cloning of PostgresWriter for periodic flush tasks
+impl Clone for PostgresWriter {
+    fn clone(&self) -> Self {
+        PostgresWriter {
+            client: Arc::clone(&self.client),
+            account_buffer: Arc::clone(&self.account_buffer),
+            transaction_buffer: Arc::clone(&self.transaction_buffer),
+            max_buffer_size: self.max_buffer_size,
+            flush_interval: self.flush_interval,
+        }
+    }
+}

--- a/examples/meteora-activities/Cargo.toml
+++ b/examples/meteora-activities/Cargo.toml
@@ -7,6 +7,7 @@ edition = { workspace = true }
 carbon-core = { workspace = true }
 carbon-log-metrics = { workspace = true }
 carbon-meteora-dlmm-decoder = { workspace = true }
+carbon-postgres-datasink = { workspace = true }
 carbon-rpc-transaction-crawler-datasource = { workspace = true }
 solana-commitment-config = { workspace = true }
 

--- a/examples/meteora-activities/src/main.rs
+++ b/examples/meteora-activities/src/main.rs
@@ -1,3 +1,4 @@
+use carbon_postgres_datasink::PostgresWriter;
 use {
     async_trait::async_trait,
     carbon_core::{
@@ -32,8 +33,14 @@ pub async fn main() -> CarbonResult<()> {
         5,                                       // Max Concurrent Requests
     );
 
+    let postgres_writer =
+        PostgresWriter::new(&env::var("POSTGRES_URL").unwrap_or_default(), 1000, 3)
+            .await
+            .unwrap();
+
     carbon_core::pipeline::Pipeline::builder()
         .datasource(transaction_crawler)
+        .datasink(postgres_writer)
         .metrics(Arc::new(LogMetrics::new()))
         .metrics_flush_interval(3)
         .instruction(MeteoraDlmmDecoder, MeteoraInstructionProcessor)


### PR DESCRIPTION
# Overview

This PR allows us to implement basic Data Sinks. The idea is that we would be able to pass the data down to a DB, stream, Cache, etc. Handles this proposal: https://github.com/sevenlabs-hq/carbon/issues/311

# Implementation Details and Thoughts:

1. This is a rough implementation for now, hasn't been tested and I told some shortcuts but wanted to get some early feedback.
2. For transaction writing, you will notice I use `UiTransactionStatusMeta` because `TransactionStatusMeta` is not `Serialize-able`. This is something worth considering.
3. I would likely also want to add read methods to this so implementers are forced to handle the reading of the data back into the original data structure.

Please let me know your thoughts and any feedback.