### PR TITLE
fix: decoders cargo-test compile fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ solana-native-token = "2.2"
 solana-program = "2.2"
 solana-program-pack = "2.2"
 solana-pubkey = { version = "2.2", features = ["serde"] }
-solana-signature = "2.2"
+solana-signature = { version = "2.2", features = ["rand"] }
 solana-transaction = "2.2"
 solana-transaction-context = "2.2"
 solana-transaction-status = "2.2"
@@ -158,7 +158,7 @@ sqlx = { version = "0.8.5", features = [
 sqlx_migrator = { version = "0.17.0", features = ["postgres"] }
 syn = { version = "1.0", features = ["full"] }
 thiserror = { version = "2.0.12", default-features = false }
-tokio = { version = "1.43.0" }
+tokio = { version = "1.43.0", features = ["rt", "time", "signal", "macros"] }
 tokio-retry = "0.3.0"
 tokio-util = "0.7.13"
 tonic = { version = "0.10", features = ["tls", "tls-roots", "tls-webpki-roots"] }


### PR DESCRIPTION
all decoder tests were failing due to compilation issues. this commit updates the crates to allow the tests to run again.