### PR TITLE
Add basic account pre process

### DIFF
--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -44,6 +44,8 @@ pub enum Error {
     MissingInstructionData,
     #[error("Failed to consume datasource ({0})")]
     FailedToConsumeDatasource(String),
+    #[error("Pre-processing error: {0}")]
+    PreProcessingError(String),
     #[error("Custom error: {0}")]
     Custom(String),
 }

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -50,6 +50,7 @@
 //! - Proper metric collection and flushing are essential for monitoring
 //!   pipeline performance, especially in production environments.
 
+use crate::account::PreProcessor;
 use crate::block_details::{BlockDetailsPipe, BlockDetailsPipes};
 use crate::datasource::BlockDetails;
 use {
@@ -769,6 +770,7 @@ impl PipelineBuilder {
         mut self,
         decoder: impl for<'a> AccountDecoder<'a, AccountType = T> + Send + Sync + 'static,
         processor: impl Processor<InputType = AccountProcessorInputType<T>> + Send + Sync + 'static,
+        pre_processor: impl PreProcessor + Send + Sync + 'static,
     ) -> Self {
         log::trace!(
             "account(self, decoder: {:?}, processor: {:?})",
@@ -778,6 +780,7 @@ impl PipelineBuilder {
         self.account_pipes.push(Box::new(AccountPipe {
             decoder: Box::new(decoder),
             processor: Box::new(processor),
+            pre_processor: pre_processor,
         }));
         self
     }


### PR DESCRIPTION
So instead of using a data sink, we can allow the users to specify how they want to preprocess the data.

If they want to write it to a DB they can, if they want to dump it to Kafka, they can. Whatever they want to do with the raw data.

This solves for keeping the raw data around. I still need to figure out a clean way to read the raw data and pass it through to the process pipeline instead of having the current pipeline get it from the data sources....

Perhaps the best way to do that would be for users to build their own custom data source (IE in my case, specify how to read that data from my DB for backfilling). 