### PR TITLE
Return Raw Account + Instructions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3956,6 +3956,7 @@ dependencies = [
  "dotenv",
  "env_logger 0.11.8",
  "log",
+ "solana-account",
  "tokio",
  "yellowstone-grpc-proto",
 ]
@@ -5382,6 +5383,7 @@ dependencies = [
  "env_logger 0.11.8",
  "log",
  "rustls 0.23.27",
+ "solana-account",
  "tokio",
  "yellowstone-grpc-proto",
 ]
@@ -9672,6 +9674,7 @@ dependencies = [
  "juniper",
  "log",
  "rustls 0.23.27",
+ "solana-account",
  "spl-token 6.0.0",
  "tokio",
  "yellowstone-grpc-proto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,6 +1139,7 @@ dependencies = [
  "dotenv",
  "env_logger 0.11.8",
  "log",
+ "solana-instruction",
  "solana-transaction-status",
  "tokio",
 ]
@@ -3941,6 +3942,7 @@ dependencies = [
  "env_logger 0.11.8",
  "log",
  "rustls 0.23.27",
+ "solana-instruction",
  "tokio",
  "yellowstone-grpc-proto",
 ]
@@ -3957,6 +3959,7 @@ dependencies = [
  "env_logger 0.11.8",
  "log",
  "solana-account",
+ "solana-instruction",
  "tokio",
  "yellowstone-grpc-proto",
 ]
@@ -4199,6 +4202,7 @@ dependencies = [
  "dotenv",
  "env_logger 0.11.8",
  "solana-commitment-config",
+ "solana-instruction",
  "tokio",
 ]
 
@@ -4316,6 +4320,7 @@ dependencies = [
  "env_logger 0.11.8",
  "log",
  "solana-client",
+ "solana-instruction",
  "tokio",
 ]
 
@@ -4617,6 +4622,7 @@ dependencies = [
  "env_logger 0.11.8",
  "log",
  "solana-client",
+ "solana-instruction",
  "tokio",
 ]
 
@@ -5384,6 +5390,7 @@ dependencies = [
  "log",
  "rustls 0.23.27",
  "solana-account",
+ "solana-instruction",
  "tokio",
  "yellowstone-grpc-proto",
 ]
@@ -5401,6 +5408,7 @@ dependencies = [
  "env_logger 0.11.8",
  "log",
  "solana-client",
+ "solana-instruction",
  "tokio",
 ]
 
@@ -5417,6 +5425,7 @@ dependencies = [
  "env_logger 0.11.8",
  "log",
  "solana-client",
+ "solana-instruction",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,7 +1139,6 @@ dependencies = [
  "dotenv",
  "env_logger 0.11.8",
  "log",
- "solana-instruction",
  "solana-transaction-status",
  "tokio",
 ]

--- a/crates/core/src/account.rs
+++ b/crates/core/src/account.rs
@@ -122,6 +122,12 @@ pub trait AccountDecoder<'a> {
     ) -> Option<DecodedAccount<Self::AccountType>>;
 }
 
+/// The input type for the account processor with the raw account data.
+///
+/// - `T`: The account type, as determined by the decoder.
+pub type AccountProcessorInputTypeWithRawAccount<T> =
+    (AccountMetadata, DecodedAccount<T>, solana_account::Account);
+
 /// The input type for the account processor.
 ///
 /// - `T`: The account type, as determined by the decoder.
@@ -147,7 +153,11 @@ pub type AccountProcessorInputType<T> = (AccountMetadata, DecodedAccount<T>);
 ///   accounts.
 pub struct AccountPipe<T: Send> {
     pub decoder: Box<dyn for<'a> AccountDecoder<'a, AccountType = T> + Send + Sync + 'static>,
-    pub processor: Box<dyn Processor<InputType = AccountProcessorInputType<T>> + Send + Sync>,
+    pub processor:
+        Option<Box<dyn Processor<InputType = AccountProcessorInputType<T>> + Send + Sync>>,
+    pub processor_with_raw: Option<
+        Box<dyn Processor<InputType = AccountProcessorInputTypeWithRawAccount<T>> + Send + Sync>,
+    >,
 }
 
 /// A trait for processing account updates in the pipeline asynchronously.
@@ -205,11 +215,32 @@ impl<T: Send> AccountPipes for AccountPipe<T> {
             account_with_metadata,
         );
 
-        if let Some(decoded_account) = self.decoder.decode_account(&account_with_metadata.1) {
-            self.processor
-                .process((account_with_metadata.0, decoded_account), metrics)
-                .await?;
+        if let Some(processor) = &mut self.processor {
+            if let Some(decoded_account) = self.decoder.decode_account(&account_with_metadata.1) {
+                processor
+                    .process(
+                        (account_with_metadata.0.clone(), decoded_account),
+                        metrics.clone(),
+                    )
+                    .await?;
+            }
         }
+
+        if let Some(processor_with_raw) = &mut self.processor_with_raw {
+            if let Some(decoded_account) = self.decoder.decode_account(&account_with_metadata.1) {
+                processor_with_raw
+                    .process(
+                        (
+                            account_with_metadata.0,
+                            decoded_account,
+                            account_with_metadata.1,
+                        ),
+                        metrics,
+                    )
+                    .await?;
+            }
+        }
+
         Ok(())
     }
 }

--- a/crates/core/src/instruction.rs
+++ b/crates/core/src/instruction.rs
@@ -114,11 +114,7 @@ pub trait InstructionDecoder<'a> {
 /// The input type for the instruction processor.
 ///
 /// - `T`: The instruction type
-pub type InstructionProcessorInputType<T> = (
-    InstructionMetadata,
-    DecodedInstruction<T>,
-    NestedInstructions,
-);
+pub type InstructionProcessorInputType<T> = (NestedInstruction, DecodedInstruction<T>);
 
 /// A processing pipeline for instructions, using a decoder and processor.
 ///
@@ -178,11 +174,7 @@ impl<T: Send + 'static> InstructionPipes<'_> for InstructionPipe<T> {
         {
             self.processor
                 .process(
-                    (
-                        nested_instruction.metadata.clone(),
-                        decoded_instruction,
-                        nested_instruction.inner_instructions.clone(),
-                    ),
+                    (nested_instruction.clone(), decoded_instruction),
                     metrics.clone(),
                 )
                 .await?;

--- a/crates/core/src/instruction.rs
+++ b/crates/core/src/instruction.rs
@@ -114,7 +114,11 @@ pub trait InstructionDecoder<'a> {
 /// The input type for the instruction processor.
 ///
 /// - `T`: The instruction type
-pub type InstructionProcessorInputType<T> = (NestedInstruction, DecodedInstruction<T>);
+pub type InstructionProcessorInputType<T> = (
+    InstructionMetadata,
+    DecodedInstruction<T>,
+    NestedInstructions,
+);
 
 /// A processing pipeline for instructions, using a decoder and processor.
 ///
@@ -174,7 +178,11 @@ impl<T: Send + 'static> InstructionPipes<'_> for InstructionPipe<T> {
         {
             self.processor
                 .process(
-                    (nested_instruction.clone(), decoded_instruction),
+                    (
+                        nested_instruction.metadata.clone(),
+                        decoded_instruction,
+                        nested_instruction.inner_instructions.clone(),
+                    ),
                     metrics.clone(),
                 )
                 .await?;

--- a/crates/core/src/instruction.rs
+++ b/crates/core/src/instruction.rs
@@ -118,6 +118,7 @@ pub type InstructionProcessorInputType<T> = (
     InstructionMetadata,
     DecodedInstruction<T>,
     NestedInstructions,
+    solana_instruction::Instruction,
 );
 
 /// A processing pipeline for instructions, using a decoder and processor.
@@ -182,6 +183,7 @@ impl<T: Send + 'static> InstructionPipes<'_> for InstructionPipe<T> {
                         nested_instruction.metadata.clone(),
                         decoded_instruction,
                         nested_instruction.inner_instructions.clone(),
+                        nested_instruction.instruction.clone(),
                     ),
                     metrics.clone(),
                 )

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -50,7 +50,6 @@
 //! - Proper metric collection and flushing are essential for monitoring
 //!   pipeline performance, especially in production environments.
 
-use crate::account::AccountProcessorInputTypeWithRawAccount;
 use crate::block_details::{BlockDetailsPipe, BlockDetailsPipes};
 use crate::datasource::BlockDetails;
 use {
@@ -779,49 +778,7 @@ impl PipelineBuilder {
         );
         self.account_pipes.push(Box::new(AccountPipe {
             decoder: Box::new(decoder),
-            processor: Some(Box::new(processor)),
-            processor_with_raw: None,
-        }));
-        self
-    }
-
-    /// Adds an account pipe to process account updates with the raw account data.
-    ///
-    /// Account pipes decode and process updates to accounts within the
-    /// pipeline. This method requires both an `AccountDecoder` and a
-    /// `Processor` to handle decoded account data.
-    ///
-    /// # Parameters
-    ///
-    /// - `decoder`: An `AccountDecoder` that decodes the account data.
-    /// - `processor`: A `Processor` that processes the decoded account data.
-    /// - `processor_with_raw`: A `Processor` that processes decoded account data with the raw account data.
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// use carbon_core::pipeline::PipelineBuilder;
-    ///
-    /// let builder = PipelineBuilder::new()
-    ///     .account_with_raw(MyAccountDecoder, MyAccountProcessor);
-    /// ```
-    pub fn account_with_raw<T: Send + Sync + 'static>(
-        mut self,
-        decoder: impl for<'a> AccountDecoder<'a, AccountType = T> + Send + Sync + 'static,
-        processor_with_raw: impl Processor<InputType = AccountProcessorInputTypeWithRawAccount<T>>
-            + Send
-            + Sync
-            + 'static,
-    ) -> Self {
-        log::trace!(
-            "account_with_raw(self, decoder: {:?}, processor: {:?})",
-            stringify!(decoder),
-            stringify!(processor)
-        );
-        self.account_pipes.push(Box::new(AccountPipe {
-            decoder: Box::new(decoder),
-            processor: None,
-            processor_with_raw: Some(Box::new(processor_with_raw)),
+            processor: Box::new(processor),
         }));
         self
     }

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -756,7 +756,6 @@ impl PipelineBuilder {
     ///
     /// - `decoder`: An `AccountDecoder` that decodes the account data.
     /// - `processor`: A `Processor` that processes the decoded account data.
-    /// - `processor_with_raw`: A `Processor` that processes decoded account data with the raw account data.
     ///
     /// # Example
     ///

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -50,6 +50,7 @@
 //! - Proper metric collection and flushing are essential for monitoring
 //!   pipeline performance, especially in production environments.
 
+use crate::account::AccountProcessorInputTypeWithRawAccount;
 use crate::block_details::{BlockDetailsPipe, BlockDetailsPipes};
 use crate::datasource::BlockDetails;
 use {
@@ -756,6 +757,7 @@ impl PipelineBuilder {
     ///
     /// - `decoder`: An `AccountDecoder` that decodes the account data.
     /// - `processor`: A `Processor` that processes the decoded account data.
+    /// - `processor_with_raw`: A `Processor` that processes decoded account data with the raw account data.
     ///
     /// # Example
     ///
@@ -777,7 +779,49 @@ impl PipelineBuilder {
         );
         self.account_pipes.push(Box::new(AccountPipe {
             decoder: Box::new(decoder),
-            processor: Box::new(processor),
+            processor: Some(Box::new(processor)),
+            processor_with_raw: None,
+        }));
+        self
+    }
+
+    /// Adds an account pipe to process account updates with the raw account data.
+    ///
+    /// Account pipes decode and process updates to accounts within the
+    /// pipeline. This method requires both an `AccountDecoder` and a
+    /// `Processor` to handle decoded account data.
+    ///
+    /// # Parameters
+    ///
+    /// - `decoder`: An `AccountDecoder` that decodes the account data.
+    /// - `processor`: A `Processor` that processes the decoded account data.
+    /// - `processor_with_raw`: A `Processor` that processes decoded account data with the raw account data.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use carbon_core::pipeline::PipelineBuilder;
+    ///
+    /// let builder = PipelineBuilder::new()
+    ///     .account_with_raw(MyAccountDecoder, MyAccountProcessor);
+    /// ```
+    pub fn account_with_raw<T: Send + Sync + 'static>(
+        mut self,
+        decoder: impl for<'a> AccountDecoder<'a, AccountType = T> + Send + Sync + 'static,
+        processor_with_raw: impl Processor<InputType = AccountProcessorInputTypeWithRawAccount<T>>
+            + Send
+            + Sync
+            + 'static,
+    ) -> Self {
+        log::trace!(
+            "account_with_raw(self, decoder: {:?}, processor: {:?})",
+            stringify!(decoder),
+            stringify!(processor)
+        );
+        self.account_pipes.push(Box::new(AccountPipe {
+            decoder: Box::new(decoder),
+            processor: None,
+            processor_with_raw: Some(Box::new(processor_with_raw)),
         }));
         self
     }

--- a/examples/block-crawler/Cargo.toml
+++ b/examples/block-crawler/Cargo.toml
@@ -14,4 +14,5 @@ clap = { workspace = true }
 dotenv = { workspace = true }
 env_logger = { workspace = true }
 log = { workspace = true }
+solana-instruction = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/examples/block-crawler/Cargo.toml
+++ b/examples/block-crawler/Cargo.toml
@@ -14,5 +14,4 @@ clap = { workspace = true }
 dotenv = { workspace = true }
 env_logger = { workspace = true }
 log = { workspace = true }
-solana-instruction = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/examples/block-crawler/src/main.rs
+++ b/examples/block-crawler/src/main.rs
@@ -66,7 +66,8 @@ impl Processor for PumpfunInstructionProcessor {
         data: Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {
-        let (metadata, pumpfun_instruction, _) = data;
+        let (nested_instruction, pumpfun_instruction) = data;
+        let metadata = nested_instruction.metadata;
 
         match pumpfun_instruction.data {
             PumpfunInstruction::CreateEvent(create_event) => {

--- a/examples/block-crawler/src/main.rs
+++ b/examples/block-crawler/src/main.rs
@@ -66,7 +66,7 @@ impl Processor for PumpfunInstructionProcessor {
         data: Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {
-        let (metadata, pumpfun_instruction, _) = data;
+        let (metadata, pumpfun_instruction, _nested_instructions, _) = data;
 
         match pumpfun_instruction.data {
             PumpfunInstruction::CreateEvent(create_event) => {

--- a/examples/block-crawler/src/main.rs
+++ b/examples/block-crawler/src/main.rs
@@ -66,8 +66,7 @@ impl Processor for PumpfunInstructionProcessor {
         data: Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {
-        let (nested_instruction, pumpfun_instruction) = data;
-        let metadata = nested_instruction.metadata;
+        let (metadata, pumpfun_instruction, _) = data;
 
         match pumpfun_instruction.data {
             PumpfunInstruction::CreateEvent(create_event) => {

--- a/examples/jupiter-swap-alerts/Cargo.toml
+++ b/examples/jupiter-swap-alerts/Cargo.toml
@@ -13,6 +13,7 @@ async-trait = { workspace = true }
 dotenv = { workspace = true }
 env_logger = { workspace = true }
 log = { workspace = true }
+solana-instruction = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 yellowstone-grpc-proto = { workspace = true }
 

--- a/examples/jupiter-swap-alerts/src/main.rs
+++ b/examples/jupiter-swap-alerts/src/main.rs
@@ -2,7 +2,7 @@ use {
     async_trait::async_trait,
     carbon_core::{
         error::CarbonResult,
-        instruction::{DecodedInstruction, InstructionMetadata, NestedInstructions},
+        instruction::{DecodedInstruction, NestedInstruction},
         metrics::MetricsCollection,
         processor::Processor,
     },
@@ -76,16 +76,15 @@ pub struct JupiterSwapInstructionProcessor;
 #[async_trait]
 impl Processor for JupiterSwapInstructionProcessor {
     type InputType = (
-        InstructionMetadata,
+        NestedInstruction,
         DecodedInstruction<JupiterSwapInstruction>,
-        NestedInstructions,
     );
     async fn process(
         &mut self,
-        (metadata, instruction, nested_instructions): Self::InputType,
+        (nested_instruction, instruction): Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {
-        let signature = metadata.transaction_metadata.signature;
+        let signature = nested_instruction.metadata.transaction_metadata.signature;
 
         match instruction.data {
             JupiterSwapInstruction::Claim(claim) => {
@@ -105,7 +104,7 @@ impl Processor for JupiterSwapInstructionProcessor {
             }
             JupiterSwapInstruction::ExactOutRoute(exact_out_route) => {
                 assert!(
-                    !nested_instructions.is_empty(),
+                    !nested_instruction.inner_instructions.is_empty(),
                     "nested instructions empty: {} ",
                     signature
                 );
@@ -115,7 +114,7 @@ impl Processor for JupiterSwapInstructionProcessor {
             }
             JupiterSwapInstruction::Route(route) => {
                 assert!(
-                    !nested_instructions.is_empty(),
+                    !nested_instruction.inner_instructions.is_empty(),
                     "nested instructions empty: {} ",
                     signature
                 );
@@ -123,7 +122,7 @@ impl Processor for JupiterSwapInstructionProcessor {
             }
             JupiterSwapInstruction::RouteWithTokenLedger(route_with_token_ledger) => {
                 assert!(
-                    !nested_instructions.is_empty(),
+                    !nested_instruction.inner_instructions.is_empty(),
                     "nested instructions empty: {} ",
                     signature
                 );
@@ -136,7 +135,7 @@ impl Processor for JupiterSwapInstructionProcessor {
                 shared_accounts_exact_out_route,
             ) => {
                 assert!(
-                    !nested_instructions.is_empty(),
+                    !nested_instruction.inner_instructions.is_empty(),
                     "nested instructions empty: {} ",
                     signature
                 );
@@ -144,7 +143,7 @@ impl Processor for JupiterSwapInstructionProcessor {
             }
             JupiterSwapInstruction::SharedAccountsRoute(shared_accounts_route) => {
                 assert!(
-                    !nested_instructions.is_empty(),
+                    !nested_instruction.inner_instructions.is_empty(),
                     "nested instructions empty: {} ",
                     signature
                 );
@@ -154,7 +153,7 @@ impl Processor for JupiterSwapInstructionProcessor {
                 shared_accounts_route_with_token_ledger,
             ) => {
                 assert!(
-                    !nested_instructions.is_empty(),
+                    !nested_instruction.inner_instructions.is_empty(),
                     "nested instructions empty: {} ",
                     signature
                 );

--- a/examples/jupiter-swap-alerts/src/main.rs
+++ b/examples/jupiter-swap-alerts/src/main.rs
@@ -2,7 +2,7 @@ use {
     async_trait::async_trait,
     carbon_core::{
         error::CarbonResult,
-        instruction::{DecodedInstruction, NestedInstruction},
+        instruction::{DecodedInstruction, InstructionMetadata, NestedInstructions},
         metrics::MetricsCollection,
         processor::Processor,
     },
@@ -76,15 +76,16 @@ pub struct JupiterSwapInstructionProcessor;
 #[async_trait]
 impl Processor for JupiterSwapInstructionProcessor {
     type InputType = (
-        NestedInstruction,
+        InstructionMetadata,
         DecodedInstruction<JupiterSwapInstruction>,
+        NestedInstructions,
     );
     async fn process(
         &mut self,
-        (nested_instruction, instruction): Self::InputType,
+        (metadata, instruction, nested_instructions): Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {
-        let signature = nested_instruction.metadata.transaction_metadata.signature;
+        let signature = metadata.transaction_metadata.signature;
 
         match instruction.data {
             JupiterSwapInstruction::Claim(claim) => {
@@ -104,7 +105,7 @@ impl Processor for JupiterSwapInstructionProcessor {
             }
             JupiterSwapInstruction::ExactOutRoute(exact_out_route) => {
                 assert!(
-                    !nested_instruction.inner_instructions.is_empty(),
+                    !nested_instructions.is_empty(),
                     "nested instructions empty: {} ",
                     signature
                 );
@@ -114,7 +115,7 @@ impl Processor for JupiterSwapInstructionProcessor {
             }
             JupiterSwapInstruction::Route(route) => {
                 assert!(
-                    !nested_instruction.inner_instructions.is_empty(),
+                    !nested_instructions.is_empty(),
                     "nested instructions empty: {} ",
                     signature
                 );
@@ -122,7 +123,7 @@ impl Processor for JupiterSwapInstructionProcessor {
             }
             JupiterSwapInstruction::RouteWithTokenLedger(route_with_token_ledger) => {
                 assert!(
-                    !nested_instruction.inner_instructions.is_empty(),
+                    !nested_instructions.is_empty(),
                     "nested instructions empty: {} ",
                     signature
                 );
@@ -135,7 +136,7 @@ impl Processor for JupiterSwapInstructionProcessor {
                 shared_accounts_exact_out_route,
             ) => {
                 assert!(
-                    !nested_instruction.inner_instructions.is_empty(),
+                    !nested_instructions.is_empty(),
                     "nested instructions empty: {} ",
                     signature
                 );
@@ -143,7 +144,7 @@ impl Processor for JupiterSwapInstructionProcessor {
             }
             JupiterSwapInstruction::SharedAccountsRoute(shared_accounts_route) => {
                 assert!(
-                    !nested_instruction.inner_instructions.is_empty(),
+                    !nested_instructions.is_empty(),
                     "nested instructions empty: {} ",
                     signature
                 );
@@ -153,7 +154,7 @@ impl Processor for JupiterSwapInstructionProcessor {
                 shared_accounts_route_with_token_ledger,
             ) => {
                 assert!(
-                    !nested_instruction.inner_instructions.is_empty(),
+                    !nested_instructions.is_empty(),
                     "nested instructions empty: {} ",
                     signature
                 );

--- a/examples/jupiter-swap-alerts/src/main.rs
+++ b/examples/jupiter-swap-alerts/src/main.rs
@@ -79,10 +79,11 @@ impl Processor for JupiterSwapInstructionProcessor {
         InstructionMetadata,
         DecodedInstruction<JupiterSwapInstruction>,
         NestedInstructions,
+        solana_instruction::Instruction,
     );
     async fn process(
         &mut self,
-        (metadata, instruction, nested_instructions): Self::InputType,
+        (metadata, instruction, nested_instructions, _): Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {
         let signature = metadata.transaction_metadata.signature;

--- a/examples/kamino-alerts/Cargo.toml
+++ b/examples/kamino-alerts/Cargo.toml
@@ -14,5 +14,6 @@ dotenv = { workspace = true }
 env_logger = { workspace = true }
 log = { workspace = true }
 solana-account = { workspace = true }
+solana-instruction = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 yellowstone-grpc-proto = { workspace = true }

--- a/examples/kamino-alerts/Cargo.toml
+++ b/examples/kamino-alerts/Cargo.toml
@@ -13,5 +13,6 @@ async-trait = { workspace = true }
 dotenv = { workspace = true }
 env_logger = { workspace = true }
 log = { workspace = true }
+solana-account = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 yellowstone-grpc-proto = { workspace = true }

--- a/examples/kamino-alerts/src/main.rs
+++ b/examples/kamino-alerts/src/main.rs
@@ -3,7 +3,7 @@ use {
     carbon_core::{
         account::{AccountMetadata, DecodedAccount},
         error::CarbonResult,
-        instruction::{DecodedInstruction, InstructionMetadata, NestedInstructions},
+        instruction::{DecodedInstruction, NestedInstruction},
         metrics::MetricsCollection,
         processor::Processor,
     },
@@ -80,17 +80,16 @@ pub struct KaminoLendingInstructionProcessor;
 #[async_trait]
 impl Processor for KaminoLendingInstructionProcessor {
     type InputType = (
-        InstructionMetadata,
+        NestedInstruction,
         DecodedInstruction<KaminoLendingInstruction>,
-        NestedInstructions,
     );
 
     async fn process(
         &mut self,
-        (metadata, instruction, _nested_instructions): Self::InputType,
+        (nested_instruction, instruction): Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {
-        let signature = metadata.transaction_metadata.signature;
+        let signature = nested_instruction.metadata.transaction_metadata.signature;
 
         let signature = format!(
             "{}...{}",

--- a/examples/kamino-alerts/src/main.rs
+++ b/examples/kamino-alerts/src/main.rs
@@ -3,7 +3,7 @@ use {
     carbon_core::{
         account::{AccountMetadata, DecodedAccount},
         error::CarbonResult,
-        instruction::{DecodedInstruction, NestedInstruction},
+        instruction::{DecodedInstruction, InstructionMetadata, NestedInstructions},
         metrics::MetricsCollection,
         processor::Processor,
     },
@@ -80,16 +80,17 @@ pub struct KaminoLendingInstructionProcessor;
 #[async_trait]
 impl Processor for KaminoLendingInstructionProcessor {
     type InputType = (
-        NestedInstruction,
+        InstructionMetadata,
         DecodedInstruction<KaminoLendingInstruction>,
+        NestedInstructions,
     );
 
     async fn process(
         &mut self,
-        (nested_instruction, instruction): Self::InputType,
+        (metadata, instruction, _nested_instructions): Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {
-        let signature = nested_instruction.metadata.transaction_metadata.signature;
+        let signature = metadata.transaction_metadata.signature;
 
         let signature = format!(
             "{}...{}",

--- a/examples/kamino-alerts/src/main.rs
+++ b/examples/kamino-alerts/src/main.rs
@@ -111,7 +111,11 @@ impl Processor for KaminoLendingInstructionProcessor {
 pub struct KaminoLendingAccountProcessor;
 #[async_trait]
 impl Processor for KaminoLendingAccountProcessor {
-    type InputType = (AccountMetadata, DecodedAccount<KaminoLendingAccount>);
+    type InputType = (
+        AccountMetadata,
+        DecodedAccount<KaminoLendingAccount>,
+        solana_account::Account,
+    );
 
     async fn process(
         &mut self,

--- a/examples/kamino-alerts/src/main.rs
+++ b/examples/kamino-alerts/src/main.rs
@@ -83,11 +83,12 @@ impl Processor for KaminoLendingInstructionProcessor {
         InstructionMetadata,
         DecodedInstruction<KaminoLendingInstruction>,
         NestedInstructions,
+        solana_instruction::Instruction,
     );
 
     async fn process(
         &mut self,
-        (metadata, instruction, _nested_instructions): Self::InputType,
+        (metadata, instruction, _nested_instructions, _): Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {
         let signature = metadata.transaction_metadata.signature;

--- a/examples/meteora-activities/Cargo.toml
+++ b/examples/meteora-activities/Cargo.toml
@@ -13,4 +13,5 @@ solana-commitment-config = { workspace = true }
 async-trait = { workspace = true }
 dotenv = { workspace = true }
 env_logger = { workspace = true }
+solana-instruction = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/examples/meteora-activities/src/main.rs
+++ b/examples/meteora-activities/src/main.rs
@@ -52,6 +52,7 @@ impl Processor for MeteoraInstructionProcessor {
         InstructionMetadata,
         DecodedInstruction<MeteoraDlmmInstruction>,
         NestedInstructions,
+        solana_instruction::Instruction,
     );
 
     async fn process(
@@ -59,7 +60,7 @@ impl Processor for MeteoraInstructionProcessor {
         data: Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {
-        let (_instruction_metadata, decoded_instruction, _nested_instructions) = data;
+        let (_instruction_metadata, decoded_instruction, _nested_instructions, _) = data;
 
         // Process all Meteora Events and add each to DB
         match decoded_instruction.data {

--- a/examples/meteora-activities/src/main.rs
+++ b/examples/meteora-activities/src/main.rs
@@ -2,7 +2,7 @@ use {
     async_trait::async_trait,
     carbon_core::{
         error::CarbonResult,
-        instruction::{DecodedInstruction, InstructionMetadata, NestedInstructions},
+        instruction::{DecodedInstruction, NestedInstruction},
         metrics::MetricsCollection,
         processor::Processor,
     },
@@ -49,9 +49,8 @@ pub struct MeteoraInstructionProcessor;
 #[async_trait]
 impl Processor for MeteoraInstructionProcessor {
     type InputType = (
-        InstructionMetadata,
+        NestedInstruction,
         DecodedInstruction<MeteoraDlmmInstruction>,
-        NestedInstructions,
     );
 
     async fn process(
@@ -59,7 +58,7 @@ impl Processor for MeteoraInstructionProcessor {
         data: Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {
-        let (_instruction_metadata, decoded_instruction, _nested_instructions) = data;
+        let (_, decoded_instruction) = data;
 
         // Process all Meteora Events and add each to DB
         match decoded_instruction.data {

--- a/examples/meteora-activities/src/main.rs
+++ b/examples/meteora-activities/src/main.rs
@@ -2,7 +2,7 @@ use {
     async_trait::async_trait,
     carbon_core::{
         error::CarbonResult,
-        instruction::{DecodedInstruction, NestedInstruction},
+        instruction::{DecodedInstruction, InstructionMetadata, NestedInstructions},
         metrics::MetricsCollection,
         processor::Processor,
     },
@@ -49,8 +49,9 @@ pub struct MeteoraInstructionProcessor;
 #[async_trait]
 impl Processor for MeteoraInstructionProcessor {
     type InputType = (
-        NestedInstruction,
+        InstructionMetadata,
         DecodedInstruction<MeteoraDlmmInstruction>,
+        NestedInstructions,
     );
 
     async fn process(
@@ -58,7 +59,7 @@ impl Processor for MeteoraInstructionProcessor {
         data: Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {
-        let (_, decoded_instruction) = data;
+        let (_instruction_metadata, decoded_instruction, _nested_instructions) = data;
 
         // Process all Meteora Events and add each to DB
         match decoded_instruction.data {

--- a/examples/moonshot-alerts/Cargo.toml
+++ b/examples/moonshot-alerts/Cargo.toml
@@ -14,4 +14,5 @@ async-trait = { workspace = true }
 dotenv = { workspace = true }
 env_logger = { workspace = true }
 log = { workspace = true }
+solana-instruction = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/examples/moonshot-alerts/src/main.rs
+++ b/examples/moonshot-alerts/src/main.rs
@@ -3,7 +3,7 @@ use {
     carbon_core::{
         deserialize::ArrangeAccounts,
         error::CarbonResult,
-        instruction::{DecodedInstruction, InstructionMetadata, NestedInstructions},
+        instruction::{DecodedInstruction, NestedInstruction},
         metrics::MetricsCollection,
         processor::Processor,
     },
@@ -56,19 +56,15 @@ pub struct MoonshotInstructionProcessor;
 
 #[async_trait]
 impl Processor for MoonshotInstructionProcessor {
-    type InputType = (
-        InstructionMetadata,
-        DecodedInstruction<MoonshotInstruction>,
-        NestedInstructions,
-    );
+    type InputType = (NestedInstruction, DecodedInstruction<MoonshotInstruction>);
 
     async fn process(
         &mut self,
-        (metadata, instruction, _nested_instructions): Self::InputType,
+        (nested_instruction, instruction): Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {
-        let signature = metadata.transaction_metadata.signature;
-        let accounts = instruction.accounts;
+        let signature = nested_instruction.metadata.transaction_metadata.signature;
+        let accounts = nested_instruction.instruction.accounts;
 
         match instruction.data {
             MoonshotInstruction::TokenMint(token_mint) => {

--- a/examples/moonshot-alerts/src/main.rs
+++ b/examples/moonshot-alerts/src/main.rs
@@ -3,7 +3,7 @@ use {
     carbon_core::{
         deserialize::ArrangeAccounts,
         error::CarbonResult,
-        instruction::{DecodedInstruction, NestedInstruction},
+        instruction::{DecodedInstruction, InstructionMetadata, NestedInstructions},
         metrics::MetricsCollection,
         processor::Processor,
     },
@@ -56,15 +56,19 @@ pub struct MoonshotInstructionProcessor;
 
 #[async_trait]
 impl Processor for MoonshotInstructionProcessor {
-    type InputType = (NestedInstruction, DecodedInstruction<MoonshotInstruction>);
+    type InputType = (
+        InstructionMetadata,
+        DecodedInstruction<MoonshotInstruction>,
+        NestedInstructions,
+    );
 
     async fn process(
         &mut self,
-        (nested_instruction, instruction): Self::InputType,
+        (metadata, instruction, _nested_instructions): Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {
-        let signature = nested_instruction.metadata.transaction_metadata.signature;
-        let accounts = nested_instruction.instruction.accounts;
+        let signature = metadata.transaction_metadata.signature;
+        let accounts = instruction.accounts;
 
         match instruction.data {
             MoonshotInstruction::TokenMint(token_mint) => {

--- a/examples/moonshot-alerts/src/main.rs
+++ b/examples/moonshot-alerts/src/main.rs
@@ -60,11 +60,12 @@ impl Processor for MoonshotInstructionProcessor {
         InstructionMetadata,
         DecodedInstruction<MoonshotInstruction>,
         NestedInstructions,
+        solana_instruction::Instruction,
     );
 
     async fn process(
         &mut self,
-        (metadata, instruction, _nested_instructions): Self::InputType,
+        (metadata, instruction, _nested_instructions, _): Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {
         let signature = metadata.transaction_metadata.signature;

--- a/examples/openbook-v2-alerts/Cargo.toml
+++ b/examples/openbook-v2-alerts/Cargo.toml
@@ -14,4 +14,5 @@ async-trait = { workspace = true }
 dotenv = { workspace = true }
 env_logger = { workspace = true }
 log = { workspace = true }
+solana-instruction = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/examples/openbook-v2-alerts/src/main.rs
+++ b/examples/openbook-v2-alerts/src/main.rs
@@ -2,7 +2,7 @@ use {
     async_trait::async_trait,
     carbon_core::{
         error::CarbonResult,
-        instruction::{DecodedInstruction, InstructionMetadata, NestedInstructions},
+        instruction::{DecodedInstruction, NestedInstruction},
         metrics::MetricsCollection,
         processor::Processor,
     },
@@ -52,18 +52,14 @@ pub struct OpenbookV2InstructionProcessor;
 
 #[async_trait]
 impl Processor for OpenbookV2InstructionProcessor {
-    type InputType = (
-        InstructionMetadata,
-        DecodedInstruction<OpenbookV2Instruction>,
-        NestedInstructions,
-    );
+    type InputType = (NestedInstruction, DecodedInstruction<OpenbookV2Instruction>);
 
     async fn process(
         &mut self,
-        (metadata, instruction, _nested_instructions): Self::InputType,
+        (nested_instruction, instruction): Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {
-        let signature = metadata.transaction_metadata.signature;
+        let signature = nested_instruction.metadata.transaction_metadata.signature;
 
         match instruction.data {
             OpenbookV2Instruction::CreateMarket(create_market) => {

--- a/examples/openbook-v2-alerts/src/main.rs
+++ b/examples/openbook-v2-alerts/src/main.rs
@@ -56,11 +56,12 @@ impl Processor for OpenbookV2InstructionProcessor {
         InstructionMetadata,
         DecodedInstruction<OpenbookV2Instruction>,
         NestedInstructions,
+        solana_instruction::Instruction,
     );
 
     async fn process(
         &mut self,
-        (metadata, instruction, _nested_instructions): Self::InputType,
+        (metadata, instruction, _nested_instructions, _): Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {
         let signature = metadata.transaction_metadata.signature;

--- a/examples/openbook-v2-alerts/src/main.rs
+++ b/examples/openbook-v2-alerts/src/main.rs
@@ -2,7 +2,7 @@ use {
     async_trait::async_trait,
     carbon_core::{
         error::CarbonResult,
-        instruction::{DecodedInstruction, NestedInstruction},
+        instruction::{DecodedInstruction, InstructionMetadata, NestedInstructions},
         metrics::MetricsCollection,
         processor::Processor,
     },
@@ -52,14 +52,18 @@ pub struct OpenbookV2InstructionProcessor;
 
 #[async_trait]
 impl Processor for OpenbookV2InstructionProcessor {
-    type InputType = (NestedInstruction, DecodedInstruction<OpenbookV2Instruction>);
+    type InputType = (
+        InstructionMetadata,
+        DecodedInstruction<OpenbookV2Instruction>,
+        NestedInstructions,
+    );
 
     async fn process(
         &mut self,
-        (nested_instruction, instruction): Self::InputType,
+        (metadata, instruction, _nested_instructions): Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {
-        let signature = nested_instruction.metadata.transaction_metadata.signature;
+        let signature = metadata.transaction_metadata.signature;
 
         match instruction.data {
             OpenbookV2Instruction::CreateMarket(create_market) => {

--- a/examples/raydium-alerts/Cargo.toml
+++ b/examples/raydium-alerts/Cargo.toml
@@ -13,6 +13,7 @@ async-trait = { workspace = true }
 dotenv = { workspace = true }
 env_logger = { workspace = true }
 log = { workspace = true }
+solana-account = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 yellowstone-grpc-proto = { workspace = true }
 

--- a/examples/raydium-alerts/Cargo.toml
+++ b/examples/raydium-alerts/Cargo.toml
@@ -14,6 +14,7 @@ dotenv = { workspace = true }
 env_logger = { workspace = true }
 log = { workspace = true }
 solana-account = { workspace = true }
+solana-instruction = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 yellowstone-grpc-proto = { workspace = true }
 

--- a/examples/raydium-alerts/src/main.rs
+++ b/examples/raydium-alerts/src/main.rs
@@ -4,7 +4,7 @@ use {
         account::{AccountMetadata, DecodedAccount},
         deserialize::ArrangeAccounts,
         error::CarbonResult,
-        instruction::{DecodedInstruction, NestedInstruction},
+        instruction::{DecodedInstruction, InstructionMetadata, NestedInstructions},
         metrics::MetricsCollection,
         processor::Processor,
     },
@@ -92,16 +92,17 @@ pub struct RaydiumAmmV4InstructionProcessor;
 #[async_trait]
 impl Processor for RaydiumAmmV4InstructionProcessor {
     type InputType = (
-        NestedInstruction,
+        InstructionMetadata,
         DecodedInstruction<RaydiumAmmV4Instruction>,
+        NestedInstructions,
     );
 
     async fn process(
         &mut self,
-        (nested_instruction, instruction): Self::InputType,
+        (metadata, instruction, _nested_instructions): Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {
-        let signature = nested_instruction.metadata.transaction_metadata.signature;
+        let signature = metadata.transaction_metadata.signature;
         let accounts = instruction.accounts;
 
         match instruction.data {

--- a/examples/raydium-alerts/src/main.rs
+++ b/examples/raydium-alerts/src/main.rs
@@ -4,7 +4,7 @@ use {
         account::{AccountMetadata, DecodedAccount},
         deserialize::ArrangeAccounts,
         error::CarbonResult,
-        instruction::{DecodedInstruction, InstructionMetadata, NestedInstructions},
+        instruction::{DecodedInstruction, NestedInstruction},
         metrics::MetricsCollection,
         processor::Processor,
     },
@@ -92,17 +92,16 @@ pub struct RaydiumAmmV4InstructionProcessor;
 #[async_trait]
 impl Processor for RaydiumAmmV4InstructionProcessor {
     type InputType = (
-        InstructionMetadata,
+        NestedInstruction,
         DecodedInstruction<RaydiumAmmV4Instruction>,
-        NestedInstructions,
     );
 
     async fn process(
         &mut self,
-        (metadata, instruction, _nested_instructions): Self::InputType,
+        (nested_instruction, instruction): Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {
-        let signature = metadata.transaction_metadata.signature;
+        let signature = nested_instruction.metadata.transaction_metadata.signature;
         let accounts = instruction.accounts;
 
         match instruction.data {

--- a/examples/raydium-alerts/src/main.rs
+++ b/examples/raydium-alerts/src/main.rs
@@ -95,11 +95,12 @@ impl Processor for RaydiumAmmV4InstructionProcessor {
         InstructionMetadata,
         DecodedInstruction<RaydiumAmmV4Instruction>,
         NestedInstructions,
+        solana_instruction::Instruction,
     );
 
     async fn process(
         &mut self,
-        (metadata, instruction, _nested_instructions): Self::InputType,
+        (metadata, instruction, _nested_instructions, _): Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {
         let signature = metadata.transaction_metadata.signature;

--- a/examples/raydium-alerts/src/main.rs
+++ b/examples/raydium-alerts/src/main.rs
@@ -195,7 +195,11 @@ impl Processor for RaydiumAmmV4InstructionProcessor {
 pub struct RaydiumAmmV4AccountProcessor;
 #[async_trait]
 impl Processor for RaydiumAmmV4AccountProcessor {
-    type InputType = (AccountMetadata, DecodedAccount<RaydiumAmmV4Account>);
+    type InputType = (
+        AccountMetadata,
+        DecodedAccount<RaydiumAmmV4Account>,
+        solana_account::Account,
+    );
 
     async fn process(
         &mut self,

--- a/examples/raydium-clmm-alerts/Cargo.toml
+++ b/examples/raydium-clmm-alerts/Cargo.toml
@@ -9,6 +9,7 @@ carbon-log-metrics = { workspace = true }
 carbon-raydium-clmm-decoder = { workspace = true }
 carbon-rpc-block-subscribe-datasource = { workspace = true }
 solana-client = { workspace = true }
+solana-instruction = { workspace = true }
 
 async-trait = { workspace = true }
 dotenv = { workspace = true }

--- a/examples/raydium-clmm-alerts/src/main.rs
+++ b/examples/raydium-clmm-alerts/src/main.rs
@@ -57,11 +57,12 @@ impl Processor for RaydiumClmmInstructionProcessor {
         InstructionMetadata,
         DecodedInstruction<RaydiumClmmInstruction>,
         NestedInstructions,
+        solana_instruction::Instruction,
     );
 
     async fn process(
         &mut self,
-        (metadata, instruction, _nested_instructions): Self::InputType,
+        (metadata, instruction, _nested_instructions, _): Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {
         let signature = metadata.transaction_metadata.signature;

--- a/examples/raydium-clmm-alerts/src/main.rs
+++ b/examples/raydium-clmm-alerts/src/main.rs
@@ -3,7 +3,7 @@ use {
     carbon_core::{
         deserialize::ArrangeAccounts,
         error::CarbonResult,
-        instruction::{DecodedInstruction, NestedInstruction},
+        instruction::{DecodedInstruction, InstructionMetadata, NestedInstructions},
         metrics::MetricsCollection,
         processor::Processor,
     },
@@ -54,16 +54,17 @@ pub struct RaydiumClmmInstructionProcessor;
 #[async_trait]
 impl Processor for RaydiumClmmInstructionProcessor {
     type InputType = (
-        NestedInstruction,
+        InstructionMetadata,
         DecodedInstruction<RaydiumClmmInstruction>,
+        NestedInstructions,
     );
 
     async fn process(
         &mut self,
-        (nested_instruction, instruction): Self::InputType,
+        (metadata, instruction, _nested_instructions): Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {
-        let signature = nested_instruction.metadata.transaction_metadata.signature;
+        let signature = metadata.transaction_metadata.signature;
         let accounts = instruction.accounts;
 
         match instruction.data {

--- a/examples/raydium-clmm-alerts/src/main.rs
+++ b/examples/raydium-clmm-alerts/src/main.rs
@@ -3,7 +3,7 @@ use {
     carbon_core::{
         deserialize::ArrangeAccounts,
         error::CarbonResult,
-        instruction::{DecodedInstruction, InstructionMetadata, NestedInstructions},
+        instruction::{DecodedInstruction, NestedInstruction},
         metrics::MetricsCollection,
         processor::Processor,
     },
@@ -54,17 +54,16 @@ pub struct RaydiumClmmInstructionProcessor;
 #[async_trait]
 impl Processor for RaydiumClmmInstructionProcessor {
     type InputType = (
-        InstructionMetadata,
+        NestedInstruction,
         DecodedInstruction<RaydiumClmmInstruction>,
-        NestedInstructions,
     );
 
     async fn process(
         &mut self,
-        (metadata, instruction, _nested_instructions): Self::InputType,
+        (nested_instruction, instruction): Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {
-        let signature = metadata.transaction_metadata.signature;
+        let signature = nested_instruction.metadata.transaction_metadata.signature;
         let accounts = instruction.accounts;
 
         match instruction.data {

--- a/examples/raydium-cpmm-alerts/Cargo.toml
+++ b/examples/raydium-cpmm-alerts/Cargo.toml
@@ -14,4 +14,5 @@ async-trait = { workspace = true }
 dotenv = { workspace = true }
 env_logger = { workspace = true }
 log = { workspace = true }
+solana-instruction = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/examples/raydium-cpmm-alerts/src/main.rs
+++ b/examples/raydium-cpmm-alerts/src/main.rs
@@ -2,7 +2,7 @@ use {
     async_trait::async_trait,
     carbon_core::{
         error::CarbonResult,
-        instruction::{DecodedInstruction, NestedInstruction},
+        instruction::{DecodedInstruction, InstructionMetadata, NestedInstructions},
         metrics::MetricsCollection,
         processor::Processor,
     },
@@ -53,16 +53,17 @@ pub struct RaydiumCpmmInstructionProcessor;
 #[async_trait]
 impl Processor for RaydiumCpmmInstructionProcessor {
     type InputType = (
-        NestedInstruction,
+        InstructionMetadata,
         DecodedInstruction<RaydiumCpmmInstruction>,
+        NestedInstructions,
     );
 
     async fn process(
         &mut self,
-        (nested_instruction, instruction): Self::InputType,
+        (metadata, instruction, _nested_instructions): Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {
-        let signature = nested_instruction.metadata.transaction_metadata.signature;
+        let signature = metadata.transaction_metadata.signature;
 
         match instruction.data {
             RaydiumCpmmInstruction::CreateAmmConfig(create_amm_config) => {

--- a/examples/raydium-cpmm-alerts/src/main.rs
+++ b/examples/raydium-cpmm-alerts/src/main.rs
@@ -2,7 +2,7 @@ use {
     async_trait::async_trait,
     carbon_core::{
         error::CarbonResult,
-        instruction::{DecodedInstruction, InstructionMetadata, NestedInstructions},
+        instruction::{DecodedInstruction, NestedInstruction},
         metrics::MetricsCollection,
         processor::Processor,
     },
@@ -53,17 +53,16 @@ pub struct RaydiumCpmmInstructionProcessor;
 #[async_trait]
 impl Processor for RaydiumCpmmInstructionProcessor {
     type InputType = (
-        InstructionMetadata,
+        NestedInstruction,
         DecodedInstruction<RaydiumCpmmInstruction>,
-        NestedInstructions,
     );
 
     async fn process(
         &mut self,
-        (metadata, instruction, _nested_instructions): Self::InputType,
+        (nested_instruction, instruction): Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {
-        let signature = metadata.transaction_metadata.signature;
+        let signature = nested_instruction.metadata.transaction_metadata.signature;
 
         match instruction.data {
             RaydiumCpmmInstruction::CreateAmmConfig(create_amm_config) => {

--- a/examples/raydium-cpmm-alerts/src/main.rs
+++ b/examples/raydium-cpmm-alerts/src/main.rs
@@ -56,11 +56,12 @@ impl Processor for RaydiumCpmmInstructionProcessor {
         InstructionMetadata,
         DecodedInstruction<RaydiumCpmmInstruction>,
         NestedInstructions,
+        solana_instruction::Instruction,
     );
 
     async fn process(
         &mut self,
-        (metadata, instruction, _nested_instructions): Self::InputType,
+        (metadata, instruction, _nested_instructions, _): Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {
         let signature = metadata.transaction_metadata.signature;

--- a/examples/sharky-offers/src/main.rs
+++ b/examples/sharky-offers/src/main.rs
@@ -108,7 +108,7 @@ impl Processor for SharkyAccountProcessor {
         update: Self::InputType,
         _metrics: Arc<MetricsCollection>,
     ) -> CarbonResult<()> {
-        let (_metadata, account) = update;
+        let (_metadata, account, _raw_account) = update;
 
         match account.data {
             SharkyAccount::OrderBook(order_book) => {

--- a/examples/token-indexing/Cargo.toml
+++ b/examples/token-indexing/Cargo.toml
@@ -16,6 +16,7 @@ spl-token = { workspace = true }
 async-trait = { workspace = true }
 dotenv = { workspace = true }
 log = { workspace = true }
+solana-account = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 yellowstone-grpc-proto = { workspace = true }
 

--- a/examples/token-indexing/src/main.rs
+++ b/examples/token-indexing/src/main.rs
@@ -131,7 +131,11 @@ pub struct TokenProgramAccountProcessor {
 
 #[async_trait]
 impl Processor for TokenProgramAccountProcessor {
-    type InputType = (AccountMetadata, DecodedAccount<TokenProgramAccount>);
+    type InputType = (
+        AccountMetadata,
+        DecodedAccount<TokenProgramAccount>,
+        solana_account::Account,
+    );
 
     async fn process(
         &mut self,


### PR DESCRIPTION
Right now, users can access the Metadata and their decoded account data within `process`. This is great if you want your decoded data which most users want.

But I have a use case where I want both the decoded data and the raw `Account` or `Instruction` data. This implementation lets me have both. Some benefits:

1. Returns both objects
2. For instruction it returns the entire `NestedInstruction`


This solution is not backward compatible, but as you can see from my updates of the examples, its pretty simple to implement.