### PR TITLE
Clean Up Showdown

### DIFF
--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -373,6 +373,12 @@ impl Pipeline {
 
         loop {
             tokio::select! {
+                _ = datasource_cancellation_token.cancelled() => {
+                    log::trace!("datasource cancellation token cancelled, shutting down.");
+                    self.metrics.flush_metrics().await?;
+                    self.metrics.shutdown_metrics().await?;
+                    break;
+                }
                 _ = tokio::signal::ctrl_c() => {
                     log::trace!("received SIGINT, shutting down.");
                     datasource_cancellation_token.cancel();

--- a/datasources/rpc-transaction-crawler-datasource/src/lib.rs
+++ b/datasources/rpc-transaction-crawler-datasource/src/lib.rs
@@ -558,11 +558,12 @@ fn task_processor(
 
 
                     if connection_config.blocking_send {
-                        if let Err(e) = sender.send(update).await {
+                        if let Err(e) = sender.send(update.clone()).await {
                             log::warn!("Failed to send update: {:?}", e);
                             continue;
                         }
-                    } else {
+                    }
+                    if !connection_config.blocking_send {
                         if let Err(e) = sender.try_send(update) {
                             log::warn!("Failed to send update: {:?}", e);
                             continue;

--- a/datasources/rpc-transaction-crawler-datasource/src/lib.rs
+++ b/datasources/rpc-transaction-crawler-datasource/src/lib.rs
@@ -556,9 +556,7 @@ fn task_processor(
 
 
                     if let Err(e) = sender.try_send(update) {
-                        if !cancellation_token.is_cancelled() {
-                            log::error!("Failed to send update: {:?}", e);
-                        }
+                        log::warn!("Failed to send update: {:?}", e);
                         continue;
                     }
                 }

--- a/datasources/rpc-transaction-crawler-datasource/src/lib.rs
+++ b/datasources/rpc-transaction-crawler-datasource/src/lib.rs
@@ -556,9 +556,7 @@ fn task_processor(
 
 
                     if let Err(e) = sender.try_send(update) {
-                        if !cancellation_token.is_cancelled() {
                             log::warn!("Failed to send update: {:?}", e);
-                        }
                         continue;
                     }
                 }

--- a/datasources/rpc-transaction-crawler-datasource/src/lib.rs
+++ b/datasources/rpc-transaction-crawler-datasource/src/lib.rs
@@ -556,7 +556,9 @@ fn task_processor(
 
 
                     if let Err(e) = sender.try_send(update) {
-                        log::warn!("Failed to send update: {:?}", e);
+                        if !cancellation_token.is_cancelled() {
+                            log::warn!("Failed to send update: {:?}", e);
+                        }
                         continue;
                     }
                 }

--- a/datasources/rpc-transaction-crawler-datasource/src/lib.rs
+++ b/datasources/rpc-transaction-crawler-datasource/src/lib.rs
@@ -556,7 +556,9 @@ fn task_processor(
 
 
                     if let Err(e) = sender.try_send(update) {
-                        log::error!("Failed to send update: {:?}", e);
+                        if !cancellation_token.is_cancelled() {
+                            log::error!("Failed to send update: {:?}", e);
+                        }
                         continue;
                     }
                 }

--- a/datasources/rpc-transaction-crawler-datasource/src/lib.rs
+++ b/datasources/rpc-transaction-crawler-datasource/src/lib.rs
@@ -246,7 +246,7 @@ fn signature_fetcher(
 
     tokio::spawn(async move {
         let mut last_fetched_signature = filters.before_signature;
-        let mut until_signature = filters.until_signature;
+        let until_signature = filters.until_signature;
         let mut most_recent_signature: Option<Signature> = None;
         loop {
             tokio::select! {
@@ -272,13 +272,9 @@ fn signature_fetcher(
                                 let start = Instant::now();
 
                                 if signatures.is_empty() {
-                                    last_fetched_signature = None;
-                                    if most_recent_signature.is_some() {
-                                        until_signature = most_recent_signature;
-                                        most_recent_signature = None;
+                                    if last_fetched_signature.is_none() {
+                                        tokio::time::sleep(connection_config.polling_interval).await;
                                     }
-
-                                    tokio::time::sleep(connection_config.polling_interval).await;
                                     break;
                                 }
 

--- a/examples/meteora-activities/src/main.rs
+++ b/examples/meteora-activities/src/main.rs
@@ -30,6 +30,7 @@ pub async fn main() -> CarbonResult<()> {
         RetryConfig::no_retry(), // Retry config
         None,                    // Max Signature Channel Size
         None,                    // Max Transaction Channel Size
+        true,                    // Blocking send
     );
 
     let transaction_crawler = RpcTransactionCrawler::new(


### PR DESCRIPTION
# Allow Users to End Pipeline
Instead of only closing on crtl_c we should allow users to specify that the pipeline is done via the cancellation token.

# Handle Proper Looping
If a filter is given, it would get all those TX but then afterward it would start getting TX from head. This is not the desired functionality and this fixes that.

Also allow users to decide on how they want their send to operate.

# Log Output

The log::error was converted to log::warn but its no longer an issue since I fixed the iteration process. Happy to revert but I actually prefer this as a warning. We don't return any errors so theres no real way for the user to take any action in any case. So in my head, a warning say "This can happen, consider blocking if you want it to go away or consume faster"