### PR TITLE
refactor: update boop decoder

### DIFF
--- a/decoders/boop-decoder/src/instructions/collect_meteora_trading_fees.rs
+++ b/decoders/boop-decoder/src/instructions/collect_meteora_trading_fees.rs
@@ -1,0 +1,64 @@
+use carbon_core::{borsh, CarbonDeserialize};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xf95f7e5b51a253fa")]
+pub struct CollectMeteoraTradingFees {}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct CollectMeteoraTradingFeesInstructionAccounts {
+    pub operator: solana_pubkey::Pubkey,
+    pub protocol_fee_recipient: solana_pubkey::Pubkey,
+    pub config: solana_pubkey::Pubkey,
+    pub pool_authority: solana_pubkey::Pubkey,
+    pub pool: solana_pubkey::Pubkey,
+    pub position: solana_pubkey::Pubkey,
+    pub token_a_account: solana_pubkey::Pubkey,
+    pub token_b_account: solana_pubkey::Pubkey,
+    pub token_a_vault: solana_pubkey::Pubkey,
+    pub token_b_vault: solana_pubkey::Pubkey,
+    pub token_a_mint: solana_pubkey::Pubkey,
+    pub token_b_mint: solana_pubkey::Pubkey,
+    pub position_nft_account: solana_pubkey::Pubkey,
+    pub vault_authority: solana_pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
+    pub associated_token_program: solana_pubkey::Pubkey,
+    pub event_authority: solana_pubkey::Pubkey,
+    pub cp_amm_program: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for CollectMeteoraTradingFees {
+    type ArrangedAccounts = CollectMeteoraTradingFeesInstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let [operator, protocol_fee_recipient, config, pool_authority, pool, position, token_a_account, token_b_account, token_a_vault, token_b_vault, token_a_mint, token_b_mint, position_nft_account, vault_authority, token_program, associated_token_program, event_authority, cp_amm_program, _remaining @ ..] =
+            accounts
+        else {
+            return None;
+        };
+
+        Some(CollectMeteoraTradingFeesInstructionAccounts {
+            operator: operator.pubkey,
+            protocol_fee_recipient: protocol_fee_recipient.pubkey,
+            config: config.pubkey,
+            pool_authority: pool_authority.pubkey,
+            pool: pool.pubkey,
+            position: position.pubkey,
+            token_a_account: token_a_account.pubkey,
+            token_b_account: token_b_account.pubkey,
+            token_a_vault: token_a_vault.pubkey,
+            token_b_vault: token_b_vault.pubkey,
+            token_a_mint: token_a_mint.pubkey,
+            token_b_mint: token_b_mint.pubkey,
+            position_nft_account: position_nft_account.pubkey,
+            vault_authority: vault_authority.pubkey,
+            token_program: token_program.pubkey,
+            associated_token_program: associated_token_program.pubkey,
+            event_authority: event_authority.pubkey,
+            cp_amm_program: cp_amm_program.pubkey,
+        })
+    }
+}

--- a/decoders/boop-decoder/src/instructions/create_meteora_pool.rs
+++ b/decoders/boop-decoder/src/instructions/create_meteora_pool.rs
@@ -1,0 +1,70 @@
+use carbon_core::{borsh, CarbonDeserialize};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xf6fe2125e1b029e8")]
+pub struct CreateMeteoraPool {}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct CreateMeteoraPoolInstructionAccounts {
+    pub operator: solana_pubkey::Pubkey,
+    pub config: solana_pubkey::Pubkey,
+    pub vault_authority: solana_pubkey::Pubkey,
+    pub cp_amm_config: solana_pubkey::Pubkey,
+    pub pool_authority: solana_pubkey::Pubkey,
+    pub pool: solana_pubkey::Pubkey,
+    pub position: solana_pubkey::Pubkey,
+    pub position_nft_mint: solana_pubkey::Pubkey,
+    pub position_nft_account: solana_pubkey::Pubkey,
+    pub token_a_mint: solana_pubkey::Pubkey,
+    pub token_b_mint: solana_pubkey::Pubkey,
+    pub token_a_vault: solana_pubkey::Pubkey,
+    pub token_b_vault: solana_pubkey::Pubkey,
+    pub bonding_curve: solana_pubkey::Pubkey,
+    pub bonding_curve_vault: solana_pubkey::Pubkey,
+    pub bonding_curve_wsol_vault: solana_pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
+    pub token_2022_program: solana_pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
+    pub event_authority: solana_pubkey::Pubkey,
+    pub cp_amm_program: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for CreateMeteoraPool {
+    type ArrangedAccounts = CreateMeteoraPoolInstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let [operator, config, vault_authority, cp_amm_config, pool_authority, pool, position, position_nft_mint, position_nft_account, token_a_mint, token_b_mint, token_a_vault, token_b_vault, bonding_curve, bonding_curve_vault, bonding_curve_wsol_vault, token_program, token_2022_program, system_program, event_authority, cp_amm_program, _remaining @ ..] =
+            accounts
+        else {
+            return None;
+        };
+
+        Some(CreateMeteoraPoolInstructionAccounts {
+            operator: operator.pubkey,
+            config: config.pubkey,
+            vault_authority: vault_authority.pubkey,
+            cp_amm_config: cp_amm_config.pubkey,
+            pool_authority: pool_authority.pubkey,
+            pool: pool.pubkey,
+            position: position.pubkey,
+            position_nft_mint: position_nft_mint.pubkey,
+            position_nft_account: position_nft_account.pubkey,
+            token_a_mint: token_a_mint.pubkey,
+            token_b_mint: token_b_mint.pubkey,
+            token_a_vault: token_a_vault.pubkey,
+            token_b_vault: token_b_vault.pubkey,
+            bonding_curve: bonding_curve.pubkey,
+            bonding_curve_vault: bonding_curve_vault.pubkey,
+            bonding_curve_wsol_vault: bonding_curve_wsol_vault.pubkey,
+            token_program: token_program.pubkey,
+            token_2022_program: token_2022_program.pubkey,
+            system_program: system_program.pubkey,
+            event_authority: event_authority.pubkey,
+            cp_amm_program: cp_amm_program.pubkey,
+        })
+    }
+}

--- a/decoders/boop-decoder/src/instructions/mod.rs
+++ b/decoders/boop-decoder/src/instructions/mod.rs
@@ -11,9 +11,11 @@ pub mod bonding_curve_vault_closed_event;
 pub mod buy_token;
 pub mod cancel_authority_transfer;
 pub mod close_bonding_curve_vault;
+pub mod collect_meteora_trading_fees;
 pub mod collect_trading_fees;
 pub mod complete_authority_transfer;
 pub mod config_updated_event;
+pub mod create_meteora_pool;
 pub mod create_raydium_pool;
 pub mod create_raydium_random_pool;
 pub mod create_token;
@@ -64,8 +66,10 @@ pub enum BoopInstruction {
     BuyToken(buy_token::BuyToken),
     CancelAuthorityTransfer(cancel_authority_transfer::CancelAuthorityTransfer),
     CloseBondingCurveVault(close_bonding_curve_vault::CloseBondingCurveVault),
+    CollectMeteoraTradingFees(collect_meteora_trading_fees::CollectMeteoraTradingFees),
     CollectTradingFees(collect_trading_fees::CollectTradingFees),
     CompleteAuthorityTransfer(complete_authority_transfer::CompleteAuthorityTransfer),
+    CreateMeteoraPool(create_meteora_pool::CreateMeteoraPool),
     CreateRaydiumPool(create_raydium_pool::CreateRaydiumPool),
     CreateRaydiumRandomPool(create_raydium_random_pool::CreateRaydiumRandomPool),
     CreateToken(create_token::CreateToken),
@@ -139,8 +143,10 @@ impl carbon_core::instruction::InstructionDecoder<'_> for BoopDecoder {
             BoopInstruction::BuyToken => buy_token::BuyToken,
             BoopInstruction::CancelAuthorityTransfer => cancel_authority_transfer::CancelAuthorityTransfer,
             BoopInstruction::CloseBondingCurveVault => close_bonding_curve_vault::CloseBondingCurveVault,
+            BoopInstruction::CollectMeteoraTradingFees => collect_meteora_trading_fees::CollectMeteoraTradingFees,
             BoopInstruction::CollectTradingFees => collect_trading_fees::CollectTradingFees,
             BoopInstruction::CompleteAuthorityTransfer => complete_authority_transfer::CompleteAuthorityTransfer,
+            BoopInstruction::CreateMeteoraPool => create_meteora_pool::CreateMeteoraPool,
             BoopInstruction::CreateRaydiumPool => create_raydium_pool::CreateRaydiumPool,
             BoopInstruction::CreateRaydiumRandomPool => create_raydium_random_pool::CreateRaydiumRandomPool,
             BoopInstruction::CreateToken => create_token::CreateToken,


### PR DESCRIPTION
Fix #362 . 

On commit 50dd8b7 used command:
```sh
carbon-cli parse --idl boop8hVGQGqehUK2iVEMEnMrL5RbjywRzHKBmBE7ry4 -u mainnet-beta
```
to update decoders.