### PR TITLE
feat: add support for optional account in decoders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1533,6 +1533,7 @@ name = "carbon-mpl-token-metadata-decoder"
 version = "0.9.0"
 dependencies = [
  "carbon-core",
+ "carbon-test-utils",
  "serde",
  "solana-account",
  "solana-instruction",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,37 +23,27 @@ borsh = { version = "1.5.1" }
 borsh-derive-internal = "0.10.3"
 bs58 = { version = "0.5.1", default-features = false }
 
-# main
-carbon-cli = { path = "crates/cli", version = "0.9.0" }
-carbon-core = { path = "crates/core", version = "0.9.0" }
-carbon-macros = { path = "crates/macros", version = "0.9.0" }
-carbon-proc-macros = { path = "crates/proc-macros", version = "0.9.0" }
-carbon-test-utils = { path = "crates/test-utils", version = "0.9.0" }
-
-# storage and api
-carbon-gql-server = { path = "crates/gql-server", version = "0.9.0" }
-carbon-postgres-client = { path = "crates/postgres-client", version = "0.9.0" }
-
-# datasources
-carbon-helius-atlas-ws-datasource = { path = "datasources/helius-atlas-ws-datasource", version = "0.9.0" }
-carbon-jito-shredstream-grpc-datasource = { path = "datasources/jito-shredstream-grpc-datasource", version = "0.9.0" }
-carbon-rpc-block-crawler-datasource = { path = "datasources/rpc-block-crawler-datasource", version = "0.9.0" }
-carbon-rpc-block-subscribe-datasource = { path = "datasources/rpc-block-subscribe-datasource", version = "0.9.0" }
-carbon-rpc-program-subscribe-datasource = { path = "datasources/rpc-program-subscribe-datasource", version = "0.9.0" }
-carbon-rpc-transaction-crawler-datasource = { path = "datasources/rpc-transaction-crawler-datasource", version = "0.9.0" }
-carbon-yellowstone-grpc-datasource = { path = "datasources/yellowstone-grpc-datasource", version = "0.9.0" }
-
-# metrics
-carbon-log-metrics = { path = "metrics/log-metrics", version = "0.9.0" }
-carbon-prometheus-metrics = { path = "metrics/prometheus-metrics", version = "0.9.0" }
-
 # decoders
 carbon-address-lookup-table-decoder = { path = "decoders/address-lookup-table-decoder", version = "0.9.0" }
 carbon-associated-token-account-decoder = { path = "decoders/associated-token-account-decoder", version = "0.9.0" }
 carbon-boop-decoder = { path = "decoders/boop-decoder", version = "0.9.0" }
+
+# main
+carbon-cli = { path = "crates/cli", version = "0.9.0" }
+carbon-core = { path = "crates/core", version = "0.9.0" }
 carbon-drift-v2-decoder = { path = "decoders/drift-v2-decoder", version = "0.9.0" }
 carbon-fluxbeam-decoder = { path = "decoders/fluxbeam-decoder", version = "0.9.0" }
 carbon-gavel-decoder = { path = "decoders/gavel-decoder", version = "0.9.0" }
+
+# storage and api
+carbon-gql-server = { path = "crates/gql-server", version = "0.9.0" }
+
+# datasources
+carbon-helius-atlas-ws-datasource = { path = "datasources/helius-atlas-ws-datasource", version = "0.9.0" }
+
+# vendor
+carbon-jito-protos = { path = "misc/jito-protos", version = "0.2.4" }
+carbon-jito-shredstream-grpc-datasource = { path = "datasources/jito-shredstream-grpc-datasource", version = "0.9.0" }
 carbon-jupiter-dca-decoder = { path = "decoders/jupiter-dca-decoder", version = "0.9.0" }
 carbon-jupiter-limit-order-2-decoder = { path = "decoders/jupiter-limit-order-2-decoder", version = "0.9.0" }
 carbon-jupiter-limit-order-decoder = { path = "decoders/jupiter-limit-order-decoder", version = "0.9.0" }
@@ -63,6 +53,10 @@ carbon-kamino-farms-decoder = { path = "decoders/kamino-farms-decoder", version 
 carbon-kamino-lending-decoder = { path = "decoders/kamino-lending-decoder", version = "0.9.0" }
 carbon-kamino-vault-decoder = { path = "decoders/kamino-vault-decoder", version = "0.9.0" }
 carbon-lifinity-amm-v2-decoder = { path = "decoders/lifinity-amm-v2-decoder", version = "0.9.0" }
+
+# metrics
+carbon-log-metrics = { path = "metrics/log-metrics", version = "0.9.0" }
+carbon-macros = { path = "crates/macros", version = "0.9.0" }
 carbon-marginfi-v2-decoder = { path = "decoders/marginfi-v2-decoder", version = "0.9.0" }
 carbon-marinade-finance-decoder = { path = "decoders/marinade-finance-decoder", version = "0.9.0" }
 carbon-memo-program-decoder = { path = "decoders/memo-program-decoder", version = "0.9.0" }
@@ -77,6 +71,9 @@ carbon-okx-dex-decoder = { path = "decoders/okx-dex-decoder", version = "0.9.0" 
 carbon-openbook-v2-decoder = { path = "decoders/openbook-v2-decoder", version = "0.9.0" }
 carbon-orca-whirlpool-decoder = { path = "decoders/orca-whirlpool-decoder", version = "0.9.0" }
 carbon-phoenix-v1-decoder = { path = "decoders/phoenix-v1-decoder", version = "0.9.0" }
+carbon-postgres-client = { path = "crates/postgres-client", version = "0.9.0" }
+carbon-proc-macros = { path = "crates/proc-macros", version = "0.9.0" }
+carbon-prometheus-metrics = { path = "metrics/prometheus-metrics", version = "0.9.0" }
 carbon-pump-swap-decoder = { path = "decoders/pump-swap-decoder", version = "0.9.0" }
 carbon-pumpfun-decoder = { path = "decoders/pumpfun-decoder", version = "0.9.0" }
 carbon-raydium-amm-v4-decoder = { path = "decoders/raydium-amm-v4-decoder", version = "0.9.0" }
@@ -85,20 +82,23 @@ carbon-raydium-cpmm-decoder = { path = "decoders/raydium-cpmm-decoder", version 
 carbon-raydium-launchpad-decoder = { path = "decoders/raydium-launchpad-decoder", version = "0.9.0" }
 carbon-raydium-liquidity-locking-decoder = { path = "decoders/carbon-raydium-liquidity-locking-decoder", version = "0.9.0" }
 carbon-raydium-stable-swap-decoder = { path = "decoders/raydium-stable-swap-decoder", version = "0.9.0" }
+carbon-rpc-block-crawler-datasource = { path = "datasources/rpc-block-crawler-datasource", version = "0.9.0" }
+carbon-rpc-block-subscribe-datasource = { path = "datasources/rpc-block-subscribe-datasource", version = "0.9.0" }
+carbon-rpc-program-subscribe-datasource = { path = "datasources/rpc-program-subscribe-datasource", version = "0.9.0" }
+carbon-rpc-transaction-crawler-datasource = { path = "datasources/rpc-transaction-crawler-datasource", version = "0.9.0" }
 carbon-sharky-decoder = { path = "decoders/sharky-decoder", version = "0.9.0" }
 carbon-solayer-restaking-program-decoder = { path = "decoders/solayer-restaking-program-decoder", version = "0.9.0" }
 carbon-stabble-stable-swap-decoder = { path = "decoders/carbon-stabble-stable-swap-decoder", version = "0.9.0" }
 carbon-stabble-weighted-swap-decoder = { path = "decoders/carbon-stabble-weighted-swap-decoder", version = "0.9.0" }
 carbon-stake-program-decoder = { path = "decoders/carbon-stake-program-decoder", version = "0.9.0" }
 carbon-system-program-decoder = { path = "decoders/system-program-decoder", version = "0.9.0" }
+carbon-test-utils = { path = "crates/test-utils", version = "0.9.0" }
 carbon-token-2022-decoder = { path = "decoders/token-2022-decoder", version = "0.9.0" }
 carbon-token-program-decoder = { path = "decoders/token-program-decoder", version = "0.9.0" }
 carbon-virtual-curve-decoder = { path = "decoders/virtual-curve-decoder", version = "0.9.0" }
 carbon-virtuals-decoder = { path = "decoders/virtuals-decoder", version = "0.9.0" }
+carbon-yellowstone-grpc-datasource = { path = "datasources/yellowstone-grpc-datasource", version = "0.9.0" }
 carbon-zeta-decoder = { path = "decoders/zeta-decoder", version = "0.9.0" }
-
-# vendor
-carbon-jito-protos = { path = "misc/jito-protos", version = "0.2.4" }
 
 # misc
 chrono = { version = "0.4.40", features = ["serde"] }

--- a/crates/cli/src/legacy_idl.rs
+++ b/crates/cli/src/legacy_idl.rs
@@ -57,7 +57,7 @@ pub struct LegacyIdlInstructionAccount {
     pub is_mut: bool,
     #[serde(default)]
     pub is_signer: bool,
-    #[serde(default)]
+    #[serde(default, alias = "optional", alias = "IsOptional")]
     pub is_optional: Option<bool>,
     #[serde(default)]
     pub docs: Option<Vec<String>>,

--- a/crates/cli/templates/instructions_struct.askama
+++ b/crates/cli/templates/instructions_struct.askama
@@ -2,7 +2,7 @@
 use super::super::types::*;
 {%- endif %}
 {% raw %}
-use carbon_core::{CarbonDeserialize, borsh};
+use carbon_core::{CarbonDeserialize, borsh, account_utils::next_account};
 {% endraw %}
 
 #[derive(CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash)]
@@ -16,7 +16,7 @@ pub struct {{ instruction.struct_name }}{
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct {{ instruction.struct_name }}InstructionAccounts {
     {%- for account in instruction.accounts %}
-    pub {{ account.name }}: solana_pubkey::Pubkey,
+    pub {{ account.name }}: {% if account.is_optional %}Option<solana_pubkey::Pubkey>{% else %}solana_pubkey::Pubkey{% endif %},
     {%- endfor %}
 }
 
@@ -24,19 +24,19 @@ impl carbon_core::deserialize::ArrangeAccounts for {{ instruction.struct_name }}
     type ArrangedAccounts = {{ instruction.struct_name }}InstructionAccounts;
 
     fn arrange_accounts(accounts: &[solana_instruction::AccountMeta]) -> Option<Self::ArrangedAccounts> {
-        let [
-            {%- for i in (0..instruction.accounts.len()) %}
-            {{ instruction.accounts[i].name }},
-            {%- endfor %}
-            _remaining @ ..
-        ] = accounts else {
-            return None;
-        };
-       
+        let mut iter = accounts.iter();
+
+        {%- for account in instruction.accounts %}
+        {%- if account.is_optional %}
+        let {{ account.name }} = next_account(&mut iter);
+        {%- else %}
+        let {{ account.name }} = next_account(&mut iter)?;
+        {%- endif %}
+        {%- endfor %}
 
         Some({{ instruction.struct_name }}InstructionAccounts {
             {%- for account in instruction.accounts %}
-            {{ account.name }}: {{ account.name }}.pubkey,
+            {{ account.name }},
             {%- endfor %}
         })
     }

--- a/crates/core/src/account_utils.rs
+++ b/crates/core/src/account_utils.rs
@@ -1,0 +1,26 @@
+use solana_instruction::AccountMeta;
+use solana_pubkey::Pubkey;
+
+/// Returns the next account's pubkey from the iterator, or `None` if there are no more accounts.
+///
+/// # Usage
+/// - Use with `?` to indicate the account is required:
+///   ```
+///   let required = next_account(&mut iter)?;
+///   ```
+///   This will propagate `None` if the account is missing.
+/// - Use without `?` to handle optional accounts:
+///   ```
+///   let optional = next_account(&mut iter);
+///   ```
+///   This returns `Option<Pubkey>` that you can match or use directly.
+///
+/// # Example
+/// ```
+/// let mut iter = accounts.iter();
+/// let required = next_account(&mut iter)?;           // required account
+/// let optional = next_account(&mut iter);            // optional account
+/// `
+pub fn next_account<'a>(iter: &mut impl Iterator<Item = &'a AccountMeta>) -> Option<Pubkey> {
+    Some(iter.next()?.pubkey)
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -120,6 +120,7 @@
 
 pub mod account;
 pub mod account_deletion;
+pub mod account_utils;
 mod block_details;
 pub mod collection;
 pub mod datasource;

--- a/decoders/mpl-token-metadata-decoder/Cargo.toml
+++ b/decoders/mpl-token-metadata-decoder/Cargo.toml
@@ -14,7 +14,10 @@ crate-type = ["rlib"]
 
 [dependencies]
 carbon-core = { workspace = true }
-serde = { workspace = true }
 solana-account = { workspace = true }
-solana-instruction = { workspace = true, default-features = false }
+solana-instruction = { workspace = true }
 solana-pubkey = { workspace = true }
+serde = { workspace = true }
+
+[dev-dependencies]
+carbon-test-utils = { workspace = true }

--- a/decoders/mpl-token-metadata-decoder/src/accounts/collection_authority_record.rs
+++ b/decoders/mpl-token-metadata-decoder/src/accounts/collection_authority_record.rs
@@ -1,9 +1,9 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
 
-#[derive(CarbonDeserialize, Debug)]
+use carbon_core::{borsh, CarbonDeserialize};
+
+#[derive(CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize)]
+#[carbon(discriminator = "0x9c306c1fd4db64a8")]
 pub struct CollectionAuthorityRecord {
     pub key: Key,
     pub bump: u8,

--- a/decoders/mpl-token-metadata-decoder/src/accounts/edition.rs
+++ b/decoders/mpl-token-metadata-decoder/src/accounts/edition.rs
@@ -1,9 +1,9 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
 
-#[derive(CarbonDeserialize, Debug)]
+use carbon_core::{borsh, CarbonDeserialize};
+
+#[derive(CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize)]
+#[carbon(discriminator = "0xea75f94a0763eba7")]
 pub struct Edition {
     pub key: Key,
     pub parent: solana_pubkey::Pubkey,

--- a/decoders/mpl-token-metadata-decoder/src/accounts/edition_marker.rs
+++ b/decoders/mpl-token-metadata-decoder/src/accounts/edition_marker.rs
@@ -1,9 +1,9 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
 
-#[derive(CarbonDeserialize, Debug)]
+use carbon_core::{borsh, CarbonDeserialize};
+
+#[derive(CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize)]
+#[carbon(discriminator = "0xe90a12e681ac25ea")]
 pub struct EditionMarker {
     pub key: Key,
     pub ledger: [u8; 31],

--- a/decoders/mpl-token-metadata-decoder/src/accounts/edition_marker_v2.rs
+++ b/decoders/mpl-token-metadata-decoder/src/accounts/edition_marker_v2.rs
@@ -1,9 +1,9 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
 
-#[derive(CarbonDeserialize, Debug)]
+use carbon_core::{borsh, CarbonDeserialize};
+
+#[derive(CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize)]
+#[carbon(discriminator = "0x837b3cfb2d02546e")]
 pub struct EditionMarkerV2 {
     pub key: Key,
     pub ledger: Vec<u8>,

--- a/decoders/mpl-token-metadata-decoder/src/accounts/holder_delegate_record.rs
+++ b/decoders/mpl-token-metadata-decoder/src/accounts/holder_delegate_record.rs
@@ -1,9 +1,9 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
 
-#[derive(CarbonDeserialize, Debug)]
+use carbon_core::{borsh, CarbonDeserialize};
+
+#[derive(CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize)]
+#[carbon(discriminator = "0x64e843a0effc0637")]
 pub struct HolderDelegateRecord {
     pub key: Key,
     pub bump: u8,

--- a/decoders/mpl-token-metadata-decoder/src/accounts/master_edition_v1.rs
+++ b/decoders/mpl-token-metadata-decoder/src/accounts/master_edition_v1.rs
@@ -1,9 +1,9 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
 
-#[derive(CarbonDeserialize, Debug)]
+use carbon_core::{borsh, CarbonDeserialize};
+
+#[derive(CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize)]
+#[carbon(discriminator = "0x4fa529a7b4bf8db9")]
 pub struct MasterEditionV1 {
     pub key: Key,
     pub supply: u64,

--- a/decoders/mpl-token-metadata-decoder/src/accounts/master_edition_v2.rs
+++ b/decoders/mpl-token-metadata-decoder/src/accounts/master_edition_v2.rs
@@ -1,9 +1,9 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
 
-#[derive(CarbonDeserialize, Debug)]
+use carbon_core::{borsh, CarbonDeserialize};
+
+#[derive(CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize)]
+#[carbon(discriminator = "0x653ba3cfee10aa9f")]
 pub struct MasterEditionV2 {
     pub key: Key,
     pub supply: u64,

--- a/decoders/mpl-token-metadata-decoder/src/accounts/metadata.rs
+++ b/decoders/mpl-token-metadata-decoder/src/accounts/metadata.rs
@@ -1,9 +1,9 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
 
-#[derive(CarbonDeserialize, Debug)]
+use carbon_core::{borsh, CarbonDeserialize};
+
+#[derive(CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize)]
+#[carbon(discriminator = "0x480b791a6fb5555d")]
 pub struct Metadata {
     pub key: Key,
     pub update_authority: solana_pubkey::Pubkey,

--- a/decoders/mpl-token-metadata-decoder/src/accounts/metadata_delegate_record.rs
+++ b/decoders/mpl-token-metadata-decoder/src/accounts/metadata_delegate_record.rs
@@ -1,9 +1,9 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
 
-#[derive(CarbonDeserialize, Debug)]
+use carbon_core::{borsh, CarbonDeserialize};
+
+#[derive(CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize)]
+#[carbon(discriminator = "0xb994256b776af3ec")]
 pub struct MetadataDelegateRecord {
     pub key: Key,
     pub bump: u8,

--- a/decoders/mpl-token-metadata-decoder/src/accounts/mod.rs
+++ b/decoders/mpl-token-metadata-decoder/src/accounts/mod.rs
@@ -1,8 +1,7 @@
-use {
-    super::TokenMetadataDecoder,
-    crate::PROGRAM_ID,
-    carbon_core::{account::AccountDecoder, deserialize::CarbonDeserialize},
-};
+use carbon_core::account::AccountDecoder;
+use carbon_core::deserialize::CarbonDeserialize;
+
+use super::TokenMetadataDecoder;
 pub mod collection_authority_record;
 pub mod edition;
 pub mod edition_marker;
@@ -41,10 +40,6 @@ impl AccountDecoder<'_> for TokenMetadataDecoder {
         &self,
         account: &solana_account::Account,
     ) -> Option<carbon_core::account::DecodedAccount<Self::AccountType>> {
-        if !account.owner.eq(&PROGRAM_ID) {
-            return None;
-        }
-
         if let Some(decoded_account) =
             collection_authority_record::CollectionAuthorityRecord::deserialize(
                 account.data.as_slice(),

--- a/decoders/mpl-token-metadata-decoder/src/accounts/reservation_list_v1.rs
+++ b/decoders/mpl-token-metadata-decoder/src/accounts/reservation_list_v1.rs
@@ -1,9 +1,9 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
 
-#[derive(CarbonDeserialize, Debug)]
+use carbon_core::{borsh, CarbonDeserialize};
+
+#[derive(CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize)]
+#[carbon(discriminator = "0xef4f0cce7499018c")]
 pub struct ReservationListV1 {
     pub key: Key,
     pub master_edition: solana_pubkey::Pubkey,

--- a/decoders/mpl-token-metadata-decoder/src/accounts/reservation_list_v2.rs
+++ b/decoders/mpl-token-metadata-decoder/src/accounts/reservation_list_v2.rs
@@ -1,9 +1,9 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
 
-#[derive(CarbonDeserialize, Debug)]
+use carbon_core::{borsh, CarbonDeserialize};
+
+#[derive(CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize)]
+#[carbon(discriminator = "0xc1e96137f58767da")]
 pub struct ReservationListV2 {
     pub key: Key,
     pub master_edition: solana_pubkey::Pubkey,

--- a/decoders/mpl-token-metadata-decoder/src/accounts/token_owned_escrow.rs
+++ b/decoders/mpl-token-metadata-decoder/src/accounts/token_owned_escrow.rs
@@ -1,9 +1,9 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
 
-#[derive(CarbonDeserialize, Debug)]
+use carbon_core::{borsh, CarbonDeserialize};
+
+#[derive(CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize)]
+#[carbon(discriminator = "0x1589745b7b627ee4")]
 pub struct TokenOwnedEscrow {
     pub key: Key,
     pub base_token: solana_pubkey::Pubkey,

--- a/decoders/mpl-token-metadata-decoder/src/accounts/token_record.rs
+++ b/decoders/mpl-token-metadata-decoder/src/accounts/token_record.rs
@@ -1,9 +1,9 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
 
-#[derive(CarbonDeserialize, Debug)]
+use carbon_core::{borsh, CarbonDeserialize};
+
+#[derive(CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize)]
+#[carbon(discriminator = "0x1bbb206489fd68f2")]
 pub struct TokenRecord {
     pub key: Key,
     pub bump: u8,

--- a/decoders/mpl-token-metadata-decoder/src/accounts/use_authority_record.rs
+++ b/decoders/mpl-token-metadata-decoder/src/accounts/use_authority_record.rs
@@ -1,9 +1,9 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
 
-#[derive(CarbonDeserialize, Debug)]
+use carbon_core::{borsh, CarbonDeserialize};
+
+#[derive(CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize)]
+#[carbon(discriminator = "0xe3c8e6c5f4c6ac32")]
 pub struct UseAuthorityRecord {
     pub key: Key,
     pub allowed_uses: u64,

--- a/decoders/mpl-token-metadata-decoder/src/instructions/_use.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/_use.rs
@@ -1,7 +1,6 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
+
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -11,19 +10,20 @@ pub struct Use {
     pub use_args: UseArgs,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct UseInstructionAccounts {
     pub authority: solana_pubkey::Pubkey,
-    pub delegate_record: solana_pubkey::Pubkey,
-    pub token: solana_pubkey::Pubkey,
+    pub delegate_record: Option<solana_pubkey::Pubkey>,
+    pub token: Option<solana_pubkey::Pubkey>,
     pub mint: solana_pubkey::Pubkey,
     pub metadata: solana_pubkey::Pubkey,
-    pub edition: solana_pubkey::Pubkey,
+    pub edition: Option<solana_pubkey::Pubkey>,
     pub payer: solana_pubkey::Pubkey,
     pub system_program: solana_pubkey::Pubkey,
     pub sysvar_instructions: solana_pubkey::Pubkey,
-    pub spl_token_program: solana_pubkey::Pubkey,
-    pub authorization_rules_program: solana_pubkey::Pubkey,
-    pub authorization_rules: solana_pubkey::Pubkey,
+    pub spl_token_program: Option<solana_pubkey::Pubkey>,
+    pub authorization_rules_program: Option<solana_pubkey::Pubkey>,
+    pub authorization_rules: Option<solana_pubkey::Pubkey>,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for Use {
@@ -32,25 +32,33 @@ impl carbon_core::deserialize::ArrangeAccounts for Use {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [authority, delegate_record, token, mint, metadata, edition, payer, system_program, sysvar_instructions, spl_token_program, authorization_rules_program, authorization_rules, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let authority = next_account(&mut iter)?;
+        let delegate_record = next_account(&mut iter);
+        let token = next_account(&mut iter);
+        let mint = next_account(&mut iter)?;
+        let metadata = next_account(&mut iter)?;
+        let edition = next_account(&mut iter);
+        let payer = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let sysvar_instructions = next_account(&mut iter)?;
+        let spl_token_program = next_account(&mut iter);
+        let authorization_rules_program = next_account(&mut iter);
+        let authorization_rules = next_account(&mut iter);
 
         Some(UseInstructionAccounts {
-            authority: authority.pubkey,
-            delegate_record: delegate_record.pubkey,
-            token: token.pubkey,
-            mint: mint.pubkey,
-            metadata: metadata.pubkey,
-            edition: edition.pubkey,
-            payer: payer.pubkey,
-            system_program: system_program.pubkey,
-            sysvar_instructions: sysvar_instructions.pubkey,
-            spl_token_program: spl_token_program.pubkey,
-            authorization_rules_program: authorization_rules_program.pubkey,
-            authorization_rules: authorization_rules.pubkey,
+            authority,
+            delegate_record,
+            token,
+            mint,
+            metadata,
+            edition,
+            payer,
+            system_program,
+            sysvar_instructions,
+            spl_token_program,
+            authorization_rules_program,
+            authorization_rules,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/approve_collection_authority.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/approve_collection_authority.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,6 +6,7 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x17")]
 pub struct ApproveCollectionAuthority {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct ApproveCollectionAuthorityInstructionAccounts {
     pub collection_authority_record: solana_pubkey::Pubkey,
     pub new_collection_authority: solana_pubkey::Pubkey,
@@ -14,7 +15,7 @@ pub struct ApproveCollectionAuthorityInstructionAccounts {
     pub metadata: solana_pubkey::Pubkey,
     pub mint: solana_pubkey::Pubkey,
     pub system_program: solana_pubkey::Pubkey,
-    pub rent: solana_pubkey::Pubkey,
+    pub rent: Option<solana_pubkey::Pubkey>,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for ApproveCollectionAuthority {
@@ -23,21 +24,25 @@ impl carbon_core::deserialize::ArrangeAccounts for ApproveCollectionAuthority {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [collection_authority_record, new_collection_authority, update_authority, payer, metadata, mint, system_program, rent, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let collection_authority_record = next_account(&mut iter)?;
+        let new_collection_authority = next_account(&mut iter)?;
+        let update_authority = next_account(&mut iter)?;
+        let payer = next_account(&mut iter)?;
+        let metadata = next_account(&mut iter)?;
+        let mint = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let rent = next_account(&mut iter);
 
         Some(ApproveCollectionAuthorityInstructionAccounts {
-            collection_authority_record: collection_authority_record.pubkey,
-            new_collection_authority: new_collection_authority.pubkey,
-            update_authority: update_authority.pubkey,
-            payer: payer.pubkey,
-            metadata: metadata.pubkey,
-            mint: mint.pubkey,
-            system_program: system_program.pubkey,
-            rent: rent.pubkey,
+            collection_authority_record,
+            new_collection_authority,
+            update_authority,
+            payer,
+            metadata,
+            mint,
+            system_program,
+            rent,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/approve_use_authority.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/approve_use_authority.rs
@@ -1,7 +1,6 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
+
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -11,6 +10,7 @@ pub struct ApproveUseAuthority {
     pub approve_use_authority_args: ApproveUseAuthorityArgs,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct ApproveUseAuthorityInstructionAccounts {
     pub use_authority_record: solana_pubkey::Pubkey,
     pub owner: solana_pubkey::Pubkey,
@@ -22,7 +22,7 @@ pub struct ApproveUseAuthorityInstructionAccounts {
     pub burner: solana_pubkey::Pubkey,
     pub token_program: solana_pubkey::Pubkey,
     pub system_program: solana_pubkey::Pubkey,
-    pub rent: solana_pubkey::Pubkey,
+    pub rent: Option<solana_pubkey::Pubkey>,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for ApproveUseAuthority {
@@ -31,24 +31,31 @@ impl carbon_core::deserialize::ArrangeAccounts for ApproveUseAuthority {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [use_authority_record, owner, payer, user, owner_token_account, metadata, mint, burner, token_program, system_program, rent, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let use_authority_record = next_account(&mut iter)?;
+        let owner = next_account(&mut iter)?;
+        let payer = next_account(&mut iter)?;
+        let user = next_account(&mut iter)?;
+        let owner_token_account = next_account(&mut iter)?;
+        let metadata = next_account(&mut iter)?;
+        let mint = next_account(&mut iter)?;
+        let burner = next_account(&mut iter)?;
+        let token_program = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let rent = next_account(&mut iter);
 
         Some(ApproveUseAuthorityInstructionAccounts {
-            use_authority_record: use_authority_record.pubkey,
-            owner: owner.pubkey,
-            payer: payer.pubkey,
-            user: user.pubkey,
-            owner_token_account: owner_token_account.pubkey,
-            metadata: metadata.pubkey,
-            mint: mint.pubkey,
-            burner: burner.pubkey,
-            token_program: token_program.pubkey,
-            system_program: system_program.pubkey,
-            rent: rent.pubkey,
+            use_authority_record,
+            owner,
+            payer,
+            user,
+            owner_token_account,
+            metadata,
+            mint,
+            burner,
+            token_program,
+            system_program,
+            rent,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/burn.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/burn.rs
@@ -1,7 +1,6 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
+
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -11,18 +10,19 @@ pub struct Burn {
     pub burn_args: BurnArgs,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct BurnInstructionAccounts {
     pub authority: solana_pubkey::Pubkey,
-    pub collection_metadata: solana_pubkey::Pubkey,
+    pub collection_metadata: Option<solana_pubkey::Pubkey>,
     pub metadata: solana_pubkey::Pubkey,
-    pub edition: solana_pubkey::Pubkey,
+    pub edition: Option<solana_pubkey::Pubkey>,
     pub mint: solana_pubkey::Pubkey,
     pub token: solana_pubkey::Pubkey,
-    pub master_edition: solana_pubkey::Pubkey,
-    pub master_edition_mint: solana_pubkey::Pubkey,
-    pub master_edition_token: solana_pubkey::Pubkey,
-    pub edition_marker: solana_pubkey::Pubkey,
-    pub token_record: solana_pubkey::Pubkey,
+    pub master_edition: Option<solana_pubkey::Pubkey>,
+    pub master_edition_mint: Option<solana_pubkey::Pubkey>,
+    pub master_edition_token: Option<solana_pubkey::Pubkey>,
+    pub edition_marker: Option<solana_pubkey::Pubkey>,
+    pub token_record: Option<solana_pubkey::Pubkey>,
     pub system_program: solana_pubkey::Pubkey,
     pub sysvar_instructions: solana_pubkey::Pubkey,
     pub spl_token_program: solana_pubkey::Pubkey,
@@ -34,27 +34,37 @@ impl carbon_core::deserialize::ArrangeAccounts for Burn {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [authority, collection_metadata, metadata, edition, mint, token, master_edition, master_edition_mint, master_edition_token, edition_marker, token_record, system_program, sysvar_instructions, spl_token_program, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let authority = next_account(&mut iter)?;
+        let collection_metadata = next_account(&mut iter);
+        let metadata = next_account(&mut iter)?;
+        let edition = next_account(&mut iter);
+        let mint = next_account(&mut iter)?;
+        let token = next_account(&mut iter)?;
+        let master_edition = next_account(&mut iter);
+        let master_edition_mint = next_account(&mut iter);
+        let master_edition_token = next_account(&mut iter);
+        let edition_marker = next_account(&mut iter);
+        let token_record = next_account(&mut iter);
+        let system_program = next_account(&mut iter)?;
+        let sysvar_instructions = next_account(&mut iter)?;
+        let spl_token_program = next_account(&mut iter)?;
 
         Some(BurnInstructionAccounts {
-            authority: authority.pubkey,
-            collection_metadata: collection_metadata.pubkey,
-            metadata: metadata.pubkey,
-            edition: edition.pubkey,
-            mint: mint.pubkey,
-            token: token.pubkey,
-            master_edition: master_edition.pubkey,
-            master_edition_mint: master_edition_mint.pubkey,
-            master_edition_token: master_edition_token.pubkey,
-            edition_marker: edition_marker.pubkey,
-            token_record: token_record.pubkey,
-            system_program: system_program.pubkey,
-            sysvar_instructions: sysvar_instructions.pubkey,
-            spl_token_program: spl_token_program.pubkey,
+            authority,
+            collection_metadata,
+            metadata,
+            edition,
+            mint,
+            token,
+            master_edition,
+            master_edition_mint,
+            master_edition_token,
+            edition_marker,
+            token_record,
+            system_program,
+            sysvar_instructions,
+            spl_token_program,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/burn_edition_nft.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/burn_edition_nft.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,6 +6,7 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x25")]
 pub struct BurnEditionNft {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct BurnEditionNftInstructionAccounts {
     pub metadata: solana_pubkey::Pubkey,
     pub owner: solana_pubkey::Pubkey,
@@ -25,23 +26,29 @@ impl carbon_core::deserialize::ArrangeAccounts for BurnEditionNft {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [metadata, owner, print_edition_mint, master_edition_mint, print_edition_token_account, master_edition_token_account, master_edition_account, print_edition_account, edition_marker_account, spl_token_program, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let metadata = next_account(&mut iter)?;
+        let owner = next_account(&mut iter)?;
+        let print_edition_mint = next_account(&mut iter)?;
+        let master_edition_mint = next_account(&mut iter)?;
+        let print_edition_token_account = next_account(&mut iter)?;
+        let master_edition_token_account = next_account(&mut iter)?;
+        let master_edition_account = next_account(&mut iter)?;
+        let print_edition_account = next_account(&mut iter)?;
+        let edition_marker_account = next_account(&mut iter)?;
+        let spl_token_program = next_account(&mut iter)?;
 
         Some(BurnEditionNftInstructionAccounts {
-            metadata: metadata.pubkey,
-            owner: owner.pubkey,
-            print_edition_mint: print_edition_mint.pubkey,
-            master_edition_mint: master_edition_mint.pubkey,
-            print_edition_token_account: print_edition_token_account.pubkey,
-            master_edition_token_account: master_edition_token_account.pubkey,
-            master_edition_account: master_edition_account.pubkey,
-            print_edition_account: print_edition_account.pubkey,
-            edition_marker_account: edition_marker_account.pubkey,
-            spl_token_program: spl_token_program.pubkey,
+            metadata,
+            owner,
+            print_edition_mint,
+            master_edition_mint,
+            print_edition_token_account,
+            master_edition_token_account,
+            master_edition_account,
+            print_edition_account,
+            edition_marker_account,
+            spl_token_program,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/close_accounts.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/close_accounts.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,6 +6,7 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x39")]
 pub struct CloseAccounts {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct CloseAccountsInstructionAccounts {
     pub metadata: solana_pubkey::Pubkey,
     pub edition: solana_pubkey::Pubkey,
@@ -20,16 +21,19 @@ impl carbon_core::deserialize::ArrangeAccounts for CloseAccounts {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [metadata, edition, mint, authority, destination, _remaining @ ..] = accounts else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let metadata = next_account(&mut iter)?;
+        let edition = next_account(&mut iter)?;
+        let mint = next_account(&mut iter)?;
+        let authority = next_account(&mut iter)?;
+        let destination = next_account(&mut iter)?;
 
         Some(CloseAccountsInstructionAccounts {
-            metadata: metadata.pubkey,
-            edition: edition.pubkey,
-            mint: mint.pubkey,
-            authority: authority.pubkey,
-            destination: destination.pubkey,
+            metadata,
+            edition,
+            mint,
+            authority,
+            destination,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/close_escrow_account.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/close_escrow_account.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,6 +6,7 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x27")]
 pub struct CloseEscrowAccount {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct CloseEscrowAccountInstructionAccounts {
     pub escrow: solana_pubkey::Pubkey,
     pub metadata: solana_pubkey::Pubkey,
@@ -23,21 +24,25 @@ impl carbon_core::deserialize::ArrangeAccounts for CloseEscrowAccount {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [escrow, metadata, mint, token_account, edition, payer, system_program, sysvar_instructions, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let escrow = next_account(&mut iter)?;
+        let metadata = next_account(&mut iter)?;
+        let mint = next_account(&mut iter)?;
+        let token_account = next_account(&mut iter)?;
+        let edition = next_account(&mut iter)?;
+        let payer = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let sysvar_instructions = next_account(&mut iter)?;
 
         Some(CloseEscrowAccountInstructionAccounts {
-            escrow: escrow.pubkey,
-            metadata: metadata.pubkey,
-            mint: mint.pubkey,
-            token_account: token_account.pubkey,
-            edition: edition.pubkey,
-            payer: payer.pubkey,
-            system_program: system_program.pubkey,
-            sysvar_instructions: sysvar_instructions.pubkey,
+            escrow,
+            metadata,
+            mint,
+            token_account,
+            edition,
+            payer,
+            system_program,
+            sysvar_instructions,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/collect.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/collect.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,6 +6,7 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x36")]
 pub struct Collect {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct CollectInstructionAccounts {
     pub authority: solana_pubkey::Pubkey,
     pub recipient: solana_pubkey::Pubkey,
@@ -17,13 +18,13 @@ impl carbon_core::deserialize::ArrangeAccounts for Collect {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [authority, recipient, _remaining @ ..] = accounts else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let authority = next_account(&mut iter)?;
+        let recipient = next_account(&mut iter)?;
 
         Some(CollectInstructionAccounts {
-            authority: authority.pubkey,
-            recipient: recipient.pubkey,
+            authority,
+            recipient,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/convert_master_edition_v1_to_v2.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/convert_master_edition_v1_to_v2.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,6 +6,7 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x0c")]
 pub struct ConvertMasterEditionV1ToV2 {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct ConvertMasterEditionV1ToV2InstructionAccounts {
     pub master_edition: solana_pubkey::Pubkey,
     pub one_time_auth: solana_pubkey::Pubkey,
@@ -18,14 +19,15 @@ impl carbon_core::deserialize::ArrangeAccounts for ConvertMasterEditionV1ToV2 {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [master_edition, one_time_auth, printing_mint, _remaining @ ..] = accounts else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let master_edition = next_account(&mut iter)?;
+        let one_time_auth = next_account(&mut iter)?;
+        let printing_mint = next_account(&mut iter)?;
 
         Some(ConvertMasterEditionV1ToV2InstructionAccounts {
-            master_edition: master_edition.pubkey,
-            one_time_auth: one_time_auth.pubkey,
-            printing_mint: printing_mint.pubkey,
+            master_edition,
+            one_time_auth,
+            printing_mint,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/create.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/create.rs
@@ -1,7 +1,6 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
+
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -11,16 +10,17 @@ pub struct Create {
     pub create_args: CreateArgs,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct CreateInstructionAccounts {
     pub metadata: solana_pubkey::Pubkey,
-    pub master_edition: solana_pubkey::Pubkey,
+    pub master_edition: Option<solana_pubkey::Pubkey>,
     pub mint: solana_pubkey::Pubkey,
     pub authority: solana_pubkey::Pubkey,
     pub payer: solana_pubkey::Pubkey,
     pub update_authority: solana_pubkey::Pubkey,
     pub system_program: solana_pubkey::Pubkey,
     pub sysvar_instructions: solana_pubkey::Pubkey,
-    pub spl_token_program: solana_pubkey::Pubkey,
+    pub spl_token_program: Option<solana_pubkey::Pubkey>,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for Create {
@@ -29,22 +29,27 @@ impl carbon_core::deserialize::ArrangeAccounts for Create {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [metadata, master_edition, mint, authority, payer, update_authority, system_program, sysvar_instructions, spl_token_program, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let metadata = next_account(&mut iter)?;
+        let master_edition = next_account(&mut iter);
+        let mint = next_account(&mut iter)?;
+        let authority = next_account(&mut iter)?;
+        let payer = next_account(&mut iter)?;
+        let update_authority = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let sysvar_instructions = next_account(&mut iter)?;
+        let spl_token_program = next_account(&mut iter);
 
         Some(CreateInstructionAccounts {
-            metadata: metadata.pubkey,
-            master_edition: master_edition.pubkey,
-            mint: mint.pubkey,
-            authority: authority.pubkey,
-            payer: payer.pubkey,
-            update_authority: update_authority.pubkey,
-            system_program: system_program.pubkey,
-            sysvar_instructions: sysvar_instructions.pubkey,
-            spl_token_program: spl_token_program.pubkey,
+            metadata,
+            master_edition,
+            mint,
+            authority,
+            payer,
+            update_authority,
+            system_program,
+            sysvar_instructions,
+            spl_token_program,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/create_escrow_account.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/create_escrow_account.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,6 +6,7 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x26")]
 pub struct CreateEscrowAccount {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct CreateEscrowAccountInstructionAccounts {
     pub escrow: solana_pubkey::Pubkey,
     pub metadata: solana_pubkey::Pubkey,
@@ -15,7 +16,7 @@ pub struct CreateEscrowAccountInstructionAccounts {
     pub payer: solana_pubkey::Pubkey,
     pub system_program: solana_pubkey::Pubkey,
     pub sysvar_instructions: solana_pubkey::Pubkey,
-    pub authority: solana_pubkey::Pubkey,
+    pub authority: Option<solana_pubkey::Pubkey>,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for CreateEscrowAccount {
@@ -24,22 +25,27 @@ impl carbon_core::deserialize::ArrangeAccounts for CreateEscrowAccount {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [escrow, metadata, mint, token_account, edition, payer, system_program, sysvar_instructions, authority, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let escrow = next_account(&mut iter)?;
+        let metadata = next_account(&mut iter)?;
+        let mint = next_account(&mut iter)?;
+        let token_account = next_account(&mut iter)?;
+        let edition = next_account(&mut iter)?;
+        let payer = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let sysvar_instructions = next_account(&mut iter)?;
+        let authority = next_account(&mut iter);
 
         Some(CreateEscrowAccountInstructionAccounts {
-            escrow: escrow.pubkey,
-            metadata: metadata.pubkey,
-            mint: mint.pubkey,
-            token_account: token_account.pubkey,
-            edition: edition.pubkey,
-            payer: payer.pubkey,
-            system_program: system_program.pubkey,
-            sysvar_instructions: sysvar_instructions.pubkey,
-            authority: authority.pubkey,
+            escrow,
+            metadata,
+            mint,
+            token_account,
+            edition,
+            payer,
+            system_program,
+            sysvar_instructions,
+            authority,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/create_master_edition.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/create_master_edition.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,6 +6,7 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x0a")]
 pub struct CreateMasterEdition {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct CreateMasterEditionInstructionAccounts {
     pub edition: solana_pubkey::Pubkey,
     pub mint: solana_pubkey::Pubkey,
@@ -24,22 +25,27 @@ impl carbon_core::deserialize::ArrangeAccounts for CreateMasterEdition {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [edition, mint, update_authority, mint_authority, payer, metadata, token_program, system_program, rent, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let edition = next_account(&mut iter)?;
+        let mint = next_account(&mut iter)?;
+        let update_authority = next_account(&mut iter)?;
+        let mint_authority = next_account(&mut iter)?;
+        let payer = next_account(&mut iter)?;
+        let metadata = next_account(&mut iter)?;
+        let token_program = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let rent = next_account(&mut iter)?;
 
         Some(CreateMasterEditionInstructionAccounts {
-            edition: edition.pubkey,
-            mint: mint.pubkey,
-            update_authority: update_authority.pubkey,
-            mint_authority: mint_authority.pubkey,
-            payer: payer.pubkey,
-            metadata: metadata.pubkey,
-            token_program: token_program.pubkey,
-            system_program: system_program.pubkey,
-            rent: rent.pubkey,
+            edition,
+            mint,
+            update_authority,
+            mint_authority,
+            payer,
+            metadata,
+            token_program,
+            system_program,
+            rent,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/create_master_edition_v3.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/create_master_edition_v3.rs
@@ -1,7 +1,6 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
+
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -11,6 +10,7 @@ pub struct CreateMasterEditionV3 {
     pub create_master_edition_args: CreateMasterEditionArgs,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct CreateMasterEditionV3InstructionAccounts {
     pub edition: solana_pubkey::Pubkey,
     pub mint: solana_pubkey::Pubkey,
@@ -20,7 +20,7 @@ pub struct CreateMasterEditionV3InstructionAccounts {
     pub metadata: solana_pubkey::Pubkey,
     pub token_program: solana_pubkey::Pubkey,
     pub system_program: solana_pubkey::Pubkey,
-    pub rent: solana_pubkey::Pubkey,
+    pub rent: Option<solana_pubkey::Pubkey>,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for CreateMasterEditionV3 {
@@ -29,22 +29,27 @@ impl carbon_core::deserialize::ArrangeAccounts for CreateMasterEditionV3 {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [edition, mint, update_authority, mint_authority, payer, metadata, token_program, system_program, rent, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let edition = next_account(&mut iter)?;
+        let mint = next_account(&mut iter)?;
+        let update_authority = next_account(&mut iter)?;
+        let mint_authority = next_account(&mut iter)?;
+        let payer = next_account(&mut iter)?;
+        let metadata = next_account(&mut iter)?;
+        let token_program = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let rent = next_account(&mut iter);
 
         Some(CreateMasterEditionV3InstructionAccounts {
-            edition: edition.pubkey,
-            mint: mint.pubkey,
-            update_authority: update_authority.pubkey,
-            mint_authority: mint_authority.pubkey,
-            payer: payer.pubkey,
-            metadata: metadata.pubkey,
-            token_program: token_program.pubkey,
-            system_program: system_program.pubkey,
-            rent: rent.pubkey,
+            edition,
+            mint,
+            update_authority,
+            mint_authority,
+            payer,
+            metadata,
+            token_program,
+            system_program,
+            rent,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/create_metadata_account.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/create_metadata_account.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,6 +6,7 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x00")]
 pub struct CreateMetadataAccount {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct CreateMetadataAccountInstructionAccounts {
     pub metadata: solana_pubkey::Pubkey,
     pub mint: solana_pubkey::Pubkey,
@@ -22,20 +23,23 @@ impl carbon_core::deserialize::ArrangeAccounts for CreateMetadataAccount {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [metadata, mint, mint_authority, payer, update_authority, system_program, rent, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let metadata = next_account(&mut iter)?;
+        let mint = next_account(&mut iter)?;
+        let mint_authority = next_account(&mut iter)?;
+        let payer = next_account(&mut iter)?;
+        let update_authority = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let rent = next_account(&mut iter)?;
 
         Some(CreateMetadataAccountInstructionAccounts {
-            metadata: metadata.pubkey,
-            mint: mint.pubkey,
-            mint_authority: mint_authority.pubkey,
-            payer: payer.pubkey,
-            update_authority: update_authority.pubkey,
-            system_program: system_program.pubkey,
-            rent: rent.pubkey,
+            metadata,
+            mint,
+            mint_authority,
+            payer,
+            update_authority,
+            system_program,
+            rent,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/create_metadata_account_v2.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/create_metadata_account_v2.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,6 +6,7 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x10")]
 pub struct CreateMetadataAccountV2 {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct CreateMetadataAccountV2InstructionAccounts {
     pub metadata: solana_pubkey::Pubkey,
     pub mint: solana_pubkey::Pubkey,
@@ -13,7 +14,7 @@ pub struct CreateMetadataAccountV2InstructionAccounts {
     pub payer: solana_pubkey::Pubkey,
     pub update_authority: solana_pubkey::Pubkey,
     pub system_program: solana_pubkey::Pubkey,
-    pub rent: solana_pubkey::Pubkey,
+    pub rent: Option<solana_pubkey::Pubkey>,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for CreateMetadataAccountV2 {
@@ -22,20 +23,23 @@ impl carbon_core::deserialize::ArrangeAccounts for CreateMetadataAccountV2 {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [metadata, mint, mint_authority, payer, update_authority, system_program, rent, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let metadata = next_account(&mut iter)?;
+        let mint = next_account(&mut iter)?;
+        let mint_authority = next_account(&mut iter)?;
+        let payer = next_account(&mut iter)?;
+        let update_authority = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let rent = next_account(&mut iter);
 
         Some(CreateMetadataAccountV2InstructionAccounts {
-            metadata: metadata.pubkey,
-            mint: mint.pubkey,
-            mint_authority: mint_authority.pubkey,
-            payer: payer.pubkey,
-            update_authority: update_authority.pubkey,
-            system_program: system_program.pubkey,
-            rent: rent.pubkey,
+            metadata,
+            mint,
+            mint_authority,
+            payer,
+            update_authority,
+            system_program,
+            rent,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/create_metadata_account_v3.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/create_metadata_account_v3.rs
@@ -1,7 +1,6 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
+
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -11,6 +10,7 @@ pub struct CreateMetadataAccountV3 {
     pub create_metadata_account_args_v3: CreateMetadataAccountArgsV3,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct CreateMetadataAccountV3InstructionAccounts {
     pub metadata: solana_pubkey::Pubkey,
     pub mint: solana_pubkey::Pubkey,
@@ -18,7 +18,7 @@ pub struct CreateMetadataAccountV3InstructionAccounts {
     pub payer: solana_pubkey::Pubkey,
     pub update_authority: solana_pubkey::Pubkey,
     pub system_program: solana_pubkey::Pubkey,
-    pub rent: solana_pubkey::Pubkey,
+    pub rent: Option<solana_pubkey::Pubkey>,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for CreateMetadataAccountV3 {
@@ -27,20 +27,23 @@ impl carbon_core::deserialize::ArrangeAccounts for CreateMetadataAccountV3 {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [metadata, mint, mint_authority, payer, update_authority, system_program, rent, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let metadata = next_account(&mut iter)?;
+        let mint = next_account(&mut iter)?;
+        let mint_authority = next_account(&mut iter)?;
+        let payer = next_account(&mut iter)?;
+        let update_authority = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let rent = next_account(&mut iter);
 
         Some(CreateMetadataAccountV3InstructionAccounts {
-            metadata: metadata.pubkey,
-            mint: mint.pubkey,
-            mint_authority: mint_authority.pubkey,
-            payer: payer.pubkey,
-            update_authority: update_authority.pubkey,
-            system_program: system_program.pubkey,
-            rent: rent.pubkey,
+            metadata,
+            mint,
+            mint_authority,
+            payer,
+            update_authority,
+            system_program,
+            rent,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/delegate.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/delegate.rs
@@ -1,7 +1,6 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
+
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -11,21 +10,22 @@ pub struct Delegate {
     pub delegate_args: DelegateArgs,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct DelegateInstructionAccounts {
-    pub delegate_record: solana_pubkey::Pubkey,
+    pub delegate_record: Option<solana_pubkey::Pubkey>,
     pub delegate: solana_pubkey::Pubkey,
     pub metadata: solana_pubkey::Pubkey,
-    pub master_edition: solana_pubkey::Pubkey,
-    pub token_record: solana_pubkey::Pubkey,
+    pub master_edition: Option<solana_pubkey::Pubkey>,
+    pub token_record: Option<solana_pubkey::Pubkey>,
     pub mint: solana_pubkey::Pubkey,
-    pub token: solana_pubkey::Pubkey,
+    pub token: Option<solana_pubkey::Pubkey>,
     pub authority: solana_pubkey::Pubkey,
     pub payer: solana_pubkey::Pubkey,
     pub system_program: solana_pubkey::Pubkey,
     pub sysvar_instructions: solana_pubkey::Pubkey,
-    pub spl_token_program: solana_pubkey::Pubkey,
-    pub authorization_rules_program: solana_pubkey::Pubkey,
-    pub authorization_rules: solana_pubkey::Pubkey,
+    pub spl_token_program: Option<solana_pubkey::Pubkey>,
+    pub authorization_rules_program: Option<solana_pubkey::Pubkey>,
+    pub authorization_rules: Option<solana_pubkey::Pubkey>,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for Delegate {
@@ -34,27 +34,37 @@ impl carbon_core::deserialize::ArrangeAccounts for Delegate {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [delegate_record, delegate, metadata, master_edition, token_record, mint, token, authority, payer, system_program, sysvar_instructions, spl_token_program, authorization_rules_program, authorization_rules, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let delegate_record = next_account(&mut iter);
+        let delegate = next_account(&mut iter)?;
+        let metadata = next_account(&mut iter)?;
+        let master_edition = next_account(&mut iter);
+        let token_record = next_account(&mut iter);
+        let mint = next_account(&mut iter)?;
+        let token = next_account(&mut iter);
+        let authority = next_account(&mut iter)?;
+        let payer = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let sysvar_instructions = next_account(&mut iter)?;
+        let spl_token_program = next_account(&mut iter);
+        let authorization_rules_program = next_account(&mut iter);
+        let authorization_rules = next_account(&mut iter);
 
         Some(DelegateInstructionAccounts {
-            delegate_record: delegate_record.pubkey,
-            delegate: delegate.pubkey,
-            metadata: metadata.pubkey,
-            master_edition: master_edition.pubkey,
-            token_record: token_record.pubkey,
-            mint: mint.pubkey,
-            token: token.pubkey,
-            authority: authority.pubkey,
-            payer: payer.pubkey,
-            system_program: system_program.pubkey,
-            sysvar_instructions: sysvar_instructions.pubkey,
-            spl_token_program: spl_token_program.pubkey,
-            authorization_rules_program: authorization_rules_program.pubkey,
-            authorization_rules: authorization_rules.pubkey,
+            delegate_record,
+            delegate,
+            metadata,
+            master_edition,
+            token_record,
+            mint,
+            token,
+            authority,
+            payer,
+            system_program,
+            sysvar_instructions,
+            spl_token_program,
+            authorization_rules_program,
+            authorization_rules,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/deprecated_create_master_edition.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/deprecated_create_master_edition.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,6 +6,7 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x02")]
 pub struct DeprecatedCreateMasterEdition {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct DeprecatedCreateMasterEditionInstructionAccounts {
     pub edition: solana_pubkey::Pubkey,
     pub mint: solana_pubkey::Pubkey,
@@ -28,27 +29,35 @@ impl carbon_core::deserialize::ArrangeAccounts for DeprecatedCreateMasterEdition
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [edition, mint, printing_mint, one_time_printing_authorization_mint, update_authority, printing_mint_authority, mint_authority, metadata, payer, token_program, system_program, rent, one_time_printing_authorization_mint_authority, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let edition = next_account(&mut iter)?;
+        let mint = next_account(&mut iter)?;
+        let printing_mint = next_account(&mut iter)?;
+        let one_time_printing_authorization_mint = next_account(&mut iter)?;
+        let update_authority = next_account(&mut iter)?;
+        let printing_mint_authority = next_account(&mut iter)?;
+        let mint_authority = next_account(&mut iter)?;
+        let metadata = next_account(&mut iter)?;
+        let payer = next_account(&mut iter)?;
+        let token_program = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let rent = next_account(&mut iter)?;
+        let one_time_printing_authorization_mint_authority = next_account(&mut iter)?;
 
         Some(DeprecatedCreateMasterEditionInstructionAccounts {
-            edition: edition.pubkey,
-            mint: mint.pubkey,
-            printing_mint: printing_mint.pubkey,
-            one_time_printing_authorization_mint: one_time_printing_authorization_mint.pubkey,
-            update_authority: update_authority.pubkey,
-            printing_mint_authority: printing_mint_authority.pubkey,
-            mint_authority: mint_authority.pubkey,
-            metadata: metadata.pubkey,
-            payer: payer.pubkey,
-            token_program: token_program.pubkey,
-            system_program: system_program.pubkey,
-            rent: rent.pubkey,
-            one_time_printing_authorization_mint_authority:
-                one_time_printing_authorization_mint_authority.pubkey,
+            edition,
+            mint,
+            printing_mint,
+            one_time_printing_authorization_mint,
+            update_authority,
+            printing_mint_authority,
+            mint_authority,
+            metadata,
+            payer,
+            token_program,
+            system_program,
+            rent,
+            one_time_printing_authorization_mint_authority,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/deprecated_create_reservation_list.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/deprecated_create_reservation_list.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,6 +6,7 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x06")]
 pub struct DeprecatedCreateReservationList {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct DeprecatedCreateReservationListInstructionAccounts {
     pub reservation_list: solana_pubkey::Pubkey,
     pub payer: solana_pubkey::Pubkey,
@@ -23,21 +24,25 @@ impl carbon_core::deserialize::ArrangeAccounts for DeprecatedCreateReservationLi
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [reservation_list, payer, update_authority, master_edition, resource, metadata, system_program, rent, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let reservation_list = next_account(&mut iter)?;
+        let payer = next_account(&mut iter)?;
+        let update_authority = next_account(&mut iter)?;
+        let master_edition = next_account(&mut iter)?;
+        let resource = next_account(&mut iter)?;
+        let metadata = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let rent = next_account(&mut iter)?;
 
         Some(DeprecatedCreateReservationListInstructionAccounts {
-            reservation_list: reservation_list.pubkey,
-            payer: payer.pubkey,
-            update_authority: update_authority.pubkey,
-            master_edition: master_edition.pubkey,
-            resource: resource.pubkey,
-            metadata: metadata.pubkey,
-            system_program: system_program.pubkey,
-            rent: rent.pubkey,
+            reservation_list,
+            payer,
+            update_authority,
+            master_edition,
+            resource,
+            metadata,
+            system_program,
+            rent,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/deprecated_mint_new_edition_from_master_edition_via_printing_token.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/deprecated_mint_new_edition_from_master_edition_via_printing_token.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,6 +6,7 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x03")]
 pub struct DeprecatedMintNewEditionFromMasterEditionViaPrintingToken {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionAccounts {
     pub metadata: solana_pubkey::Pubkey,
     pub edition: solana_pubkey::Pubkey,
@@ -22,7 +23,7 @@ pub struct DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionA
     pub token_program: solana_pubkey::Pubkey,
     pub system_program: solana_pubkey::Pubkey,
     pub rent: solana_pubkey::Pubkey,
-    pub reservation_list: solana_pubkey::Pubkey,
+    pub reservation_list: Option<solana_pubkey::Pubkey>,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts
@@ -34,30 +35,42 @@ impl carbon_core::deserialize::ArrangeAccounts
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [metadata, edition, master_edition, mint, mint_authority, printing_mint, master_token_account, edition_marker, burn_authority, payer, master_update_authority, master_metadata, token_program, system_program, rent, reservation_list, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let metadata = next_account(&mut iter)?;
+        let edition = next_account(&mut iter)?;
+        let master_edition = next_account(&mut iter)?;
+        let mint = next_account(&mut iter)?;
+        let mint_authority = next_account(&mut iter)?;
+        let printing_mint = next_account(&mut iter)?;
+        let master_token_account = next_account(&mut iter)?;
+        let edition_marker = next_account(&mut iter)?;
+        let burn_authority = next_account(&mut iter)?;
+        let payer = next_account(&mut iter)?;
+        let master_update_authority = next_account(&mut iter)?;
+        let master_metadata = next_account(&mut iter)?;
+        let token_program = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let rent = next_account(&mut iter)?;
+        let reservation_list = next_account(&mut iter);
 
         Some(
             DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionAccounts {
-                metadata: metadata.pubkey,
-                edition: edition.pubkey,
-                master_edition: master_edition.pubkey,
-                mint: mint.pubkey,
-                mint_authority: mint_authority.pubkey,
-                printing_mint: printing_mint.pubkey,
-                master_token_account: master_token_account.pubkey,
-                edition_marker: edition_marker.pubkey,
-                burn_authority: burn_authority.pubkey,
-                payer: payer.pubkey,
-                master_update_authority: master_update_authority.pubkey,
-                master_metadata: master_metadata.pubkey,
-                token_program: token_program.pubkey,
-                system_program: system_program.pubkey,
-                rent: rent.pubkey,
-                reservation_list: reservation_list.pubkey,
+                metadata,
+                edition,
+                master_edition,
+                mint,
+                mint_authority,
+                printing_mint,
+                master_token_account,
+                edition_marker,
+                burn_authority,
+                payer,
+                master_update_authority,
+                master_metadata,
+                token_program,
+                system_program,
+                rent,
+                reservation_list,
             },
         )
     }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/deprecated_mint_printing_tokens.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/deprecated_mint_printing_tokens.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,6 +6,7 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x09")]
 pub struct DeprecatedMintPrintingTokens {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct DeprecatedMintPrintingTokensInstructionAccounts {
     pub destination: solana_pubkey::Pubkey,
     pub printing_mint: solana_pubkey::Pubkey,
@@ -22,20 +23,23 @@ impl carbon_core::deserialize::ArrangeAccounts for DeprecatedMintPrintingTokens 
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [destination, printing_mint, update_authority, metadata, master_edition, token_program, rent, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let destination = next_account(&mut iter)?;
+        let printing_mint = next_account(&mut iter)?;
+        let update_authority = next_account(&mut iter)?;
+        let metadata = next_account(&mut iter)?;
+        let master_edition = next_account(&mut iter)?;
+        let token_program = next_account(&mut iter)?;
+        let rent = next_account(&mut iter)?;
 
         Some(DeprecatedMintPrintingTokensInstructionAccounts {
-            destination: destination.pubkey,
-            printing_mint: printing_mint.pubkey,
-            update_authority: update_authority.pubkey,
-            metadata: metadata.pubkey,
-            master_edition: master_edition.pubkey,
-            token_program: token_program.pubkey,
-            rent: rent.pubkey,
+            destination,
+            printing_mint,
+            update_authority,
+            metadata,
+            master_edition,
+            token_program,
+            rent,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/deprecated_mint_printing_tokens_via_token.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/deprecated_mint_printing_tokens_via_token.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,6 +6,7 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x08")]
 pub struct DeprecatedMintPrintingTokensViaToken {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct DeprecatedMintPrintingTokensViaTokenInstructionAccounts {
     pub destination: solana_pubkey::Pubkey,
     pub token: solana_pubkey::Pubkey,
@@ -24,22 +25,27 @@ impl carbon_core::deserialize::ArrangeAccounts for DeprecatedMintPrintingTokensV
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [destination, token, one_time_printing_authorization_mint, printing_mint, burn_authority, metadata, master_edition, token_program, rent, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let destination = next_account(&mut iter)?;
+        let token = next_account(&mut iter)?;
+        let one_time_printing_authorization_mint = next_account(&mut iter)?;
+        let printing_mint = next_account(&mut iter)?;
+        let burn_authority = next_account(&mut iter)?;
+        let metadata = next_account(&mut iter)?;
+        let master_edition = next_account(&mut iter)?;
+        let token_program = next_account(&mut iter)?;
+        let rent = next_account(&mut iter)?;
 
         Some(DeprecatedMintPrintingTokensViaTokenInstructionAccounts {
-            destination: destination.pubkey,
-            token: token.pubkey,
-            one_time_printing_authorization_mint: one_time_printing_authorization_mint.pubkey,
-            printing_mint: printing_mint.pubkey,
-            burn_authority: burn_authority.pubkey,
-            metadata: metadata.pubkey,
-            master_edition: master_edition.pubkey,
-            token_program: token_program.pubkey,
-            rent: rent.pubkey,
+            destination,
+            token,
+            one_time_printing_authorization_mint,
+            printing_mint,
+            burn_authority,
+            metadata,
+            master_edition,
+            token_program,
+            rent,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/deprecated_set_reservation_list.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/deprecated_set_reservation_list.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,6 +6,7 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x05")]
 pub struct DeprecatedSetReservationList {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct DeprecatedSetReservationListInstructionAccounts {
     pub master_edition: solana_pubkey::Pubkey,
     pub reservation_list: solana_pubkey::Pubkey,
@@ -18,14 +19,15 @@ impl carbon_core::deserialize::ArrangeAccounts for DeprecatedSetReservationList 
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [master_edition, reservation_list, resource, _remaining @ ..] = accounts else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let master_edition = next_account(&mut iter)?;
+        let reservation_list = next_account(&mut iter)?;
+        let resource = next_account(&mut iter)?;
 
         Some(DeprecatedSetReservationListInstructionAccounts {
-            master_edition: master_edition.pubkey,
-            reservation_list: reservation_list.pubkey,
-            resource: resource.pubkey,
+            master_edition,
+            reservation_list,
+            resource,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/freeze_delegated_account.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/freeze_delegated_account.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,6 +6,7 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x1a")]
 pub struct FreezeDelegatedAccount {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct FreezeDelegatedAccountInstructionAccounts {
     pub delegate: solana_pubkey::Pubkey,
     pub token_account: solana_pubkey::Pubkey,
@@ -20,17 +21,19 @@ impl carbon_core::deserialize::ArrangeAccounts for FreezeDelegatedAccount {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [delegate, token_account, edition, mint, token_program, _remaining @ ..] = accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let delegate = next_account(&mut iter)?;
+        let token_account = next_account(&mut iter)?;
+        let edition = next_account(&mut iter)?;
+        let mint = next_account(&mut iter)?;
+        let token_program = next_account(&mut iter)?;
 
         Some(FreezeDelegatedAccountInstructionAccounts {
-            delegate: delegate.pubkey,
-            token_account: token_account.pubkey,
-            edition: edition.pubkey,
-            mint: mint.pubkey,
-            token_program: token_program.pubkey,
+            delegate,
+            token_account,
+            edition,
+            mint,
+            token_program,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/lock.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/lock.rs
@@ -1,7 +1,6 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
+
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -11,20 +10,21 @@ pub struct Lock {
     pub lock_args: LockArgs,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct LockInstructionAccounts {
     pub authority: solana_pubkey::Pubkey,
-    pub token_owner: solana_pubkey::Pubkey,
+    pub token_owner: Option<solana_pubkey::Pubkey>,
     pub token: solana_pubkey::Pubkey,
     pub mint: solana_pubkey::Pubkey,
     pub metadata: solana_pubkey::Pubkey,
-    pub edition: solana_pubkey::Pubkey,
-    pub token_record: solana_pubkey::Pubkey,
+    pub edition: Option<solana_pubkey::Pubkey>,
+    pub token_record: Option<solana_pubkey::Pubkey>,
     pub payer: solana_pubkey::Pubkey,
     pub system_program: solana_pubkey::Pubkey,
     pub sysvar_instructions: solana_pubkey::Pubkey,
-    pub spl_token_program: solana_pubkey::Pubkey,
-    pub authorization_rules_program: solana_pubkey::Pubkey,
-    pub authorization_rules: solana_pubkey::Pubkey,
+    pub spl_token_program: Option<solana_pubkey::Pubkey>,
+    pub authorization_rules_program: Option<solana_pubkey::Pubkey>,
+    pub authorization_rules: Option<solana_pubkey::Pubkey>,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for Lock {
@@ -33,26 +33,35 @@ impl carbon_core::deserialize::ArrangeAccounts for Lock {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [authority, token_owner, token, mint, metadata, edition, token_record, payer, system_program, sysvar_instructions, spl_token_program, authorization_rules_program, authorization_rules, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let authority = next_account(&mut iter)?;
+        let token_owner = next_account(&mut iter);
+        let token = next_account(&mut iter)?;
+        let mint = next_account(&mut iter)?;
+        let metadata = next_account(&mut iter)?;
+        let edition = next_account(&mut iter);
+        let token_record = next_account(&mut iter);
+        let payer = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let sysvar_instructions = next_account(&mut iter)?;
+        let spl_token_program = next_account(&mut iter);
+        let authorization_rules_program = next_account(&mut iter);
+        let authorization_rules = next_account(&mut iter);
 
         Some(LockInstructionAccounts {
-            authority: authority.pubkey,
-            token_owner: token_owner.pubkey,
-            token: token.pubkey,
-            mint: mint.pubkey,
-            metadata: metadata.pubkey,
-            edition: edition.pubkey,
-            token_record: token_record.pubkey,
-            payer: payer.pubkey,
-            system_program: system_program.pubkey,
-            sysvar_instructions: sysvar_instructions.pubkey,
-            spl_token_program: spl_token_program.pubkey,
-            authorization_rules_program: authorization_rules_program.pubkey,
-            authorization_rules: authorization_rules.pubkey,
+            authority,
+            token_owner,
+            token,
+            mint,
+            metadata,
+            edition,
+            token_record,
+            payer,
+            system_program,
+            sysvar_instructions,
+            spl_token_program,
+            authorization_rules_program,
+            authorization_rules,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/migrate.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/migrate.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,6 +6,7 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x30")]
 pub struct Migrate {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct MigrateInstructionAccounts {
     pub metadata: solana_pubkey::Pubkey,
     pub edition: solana_pubkey::Pubkey,
@@ -20,8 +21,8 @@ pub struct MigrateInstructionAccounts {
     pub system_program: solana_pubkey::Pubkey,
     pub sysvar_instructions: solana_pubkey::Pubkey,
     pub spl_token_program: solana_pubkey::Pubkey,
-    pub authorization_rules_program: solana_pubkey::Pubkey,
-    pub authorization_rules: solana_pubkey::Pubkey,
+    pub authorization_rules_program: Option<solana_pubkey::Pubkey>,
+    pub authorization_rules: Option<solana_pubkey::Pubkey>,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for Migrate {
@@ -30,28 +31,39 @@ impl carbon_core::deserialize::ArrangeAccounts for Migrate {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [metadata, edition, token, token_owner, mint, payer, authority, collection_metadata, delegate_record, token_record, system_program, sysvar_instructions, spl_token_program, authorization_rules_program, authorization_rules, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let metadata = next_account(&mut iter)?;
+        let edition = next_account(&mut iter)?;
+        let token = next_account(&mut iter)?;
+        let token_owner = next_account(&mut iter)?;
+        let mint = next_account(&mut iter)?;
+        let payer = next_account(&mut iter)?;
+        let authority = next_account(&mut iter)?;
+        let collection_metadata = next_account(&mut iter)?;
+        let delegate_record = next_account(&mut iter)?;
+        let token_record = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let sysvar_instructions = next_account(&mut iter)?;
+        let spl_token_program = next_account(&mut iter)?;
+        let authorization_rules_program = next_account(&mut iter);
+        let authorization_rules = next_account(&mut iter);
 
         Some(MigrateInstructionAccounts {
-            metadata: metadata.pubkey,
-            edition: edition.pubkey,
-            token: token.pubkey,
-            token_owner: token_owner.pubkey,
-            mint: mint.pubkey,
-            payer: payer.pubkey,
-            authority: authority.pubkey,
-            collection_metadata: collection_metadata.pubkey,
-            delegate_record: delegate_record.pubkey,
-            token_record: token_record.pubkey,
-            system_program: system_program.pubkey,
-            sysvar_instructions: sysvar_instructions.pubkey,
-            spl_token_program: spl_token_program.pubkey,
-            authorization_rules_program: authorization_rules_program.pubkey,
-            authorization_rules: authorization_rules.pubkey,
+            metadata,
+            edition,
+            token,
+            token_owner,
+            mint,
+            payer,
+            authority,
+            collection_metadata,
+            delegate_record,
+            token_record,
+            system_program,
+            sysvar_instructions,
+            spl_token_program,
+            authorization_rules_program,
+            authorization_rules,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/mint.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/mint.rs
@@ -1,7 +1,6 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
+
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -11,22 +10,23 @@ pub struct Mint {
     pub mint_args: MintArgs,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct MintInstructionAccounts {
     pub token: solana_pubkey::Pubkey,
-    pub token_owner: solana_pubkey::Pubkey,
+    pub token_owner: Option<solana_pubkey::Pubkey>,
     pub metadata: solana_pubkey::Pubkey,
-    pub master_edition: solana_pubkey::Pubkey,
-    pub token_record: solana_pubkey::Pubkey,
+    pub master_edition: Option<solana_pubkey::Pubkey>,
+    pub token_record: Option<solana_pubkey::Pubkey>,
     pub mint: solana_pubkey::Pubkey,
     pub authority: solana_pubkey::Pubkey,
-    pub delegate_record: solana_pubkey::Pubkey,
+    pub delegate_record: Option<solana_pubkey::Pubkey>,
     pub payer: solana_pubkey::Pubkey,
     pub system_program: solana_pubkey::Pubkey,
     pub sysvar_instructions: solana_pubkey::Pubkey,
     pub spl_token_program: solana_pubkey::Pubkey,
     pub spl_ata_program: solana_pubkey::Pubkey,
-    pub authorization_rules_program: solana_pubkey::Pubkey,
-    pub authorization_rules: solana_pubkey::Pubkey,
+    pub authorization_rules_program: Option<solana_pubkey::Pubkey>,
+    pub authorization_rules: Option<solana_pubkey::Pubkey>,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for Mint {
@@ -35,28 +35,39 @@ impl carbon_core::deserialize::ArrangeAccounts for Mint {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [token, token_owner, metadata, master_edition, token_record, mint, authority, delegate_record, payer, system_program, sysvar_instructions, spl_token_program, spl_ata_program, authorization_rules_program, authorization_rules, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let token = next_account(&mut iter)?;
+        let token_owner = next_account(&mut iter);
+        let metadata = next_account(&mut iter)?;
+        let master_edition = next_account(&mut iter);
+        let token_record = next_account(&mut iter);
+        let mint = next_account(&mut iter)?;
+        let authority = next_account(&mut iter)?;
+        let delegate_record = next_account(&mut iter);
+        let payer = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let sysvar_instructions = next_account(&mut iter)?;
+        let spl_token_program = next_account(&mut iter)?;
+        let spl_ata_program = next_account(&mut iter)?;
+        let authorization_rules_program = next_account(&mut iter);
+        let authorization_rules = next_account(&mut iter);
 
         Some(MintInstructionAccounts {
-            token: token.pubkey,
-            token_owner: token_owner.pubkey,
-            metadata: metadata.pubkey,
-            master_edition: master_edition.pubkey,
-            token_record: token_record.pubkey,
-            mint: mint.pubkey,
-            authority: authority.pubkey,
-            delegate_record: delegate_record.pubkey,
-            payer: payer.pubkey,
-            system_program: system_program.pubkey,
-            sysvar_instructions: sysvar_instructions.pubkey,
-            spl_token_program: spl_token_program.pubkey,
-            spl_ata_program: spl_ata_program.pubkey,
-            authorization_rules_program: authorization_rules_program.pubkey,
-            authorization_rules: authorization_rules.pubkey,
+            token,
+            token_owner,
+            metadata,
+            master_edition,
+            token_record,
+            mint,
+            authority,
+            delegate_record,
+            payer,
+            system_program,
+            sysvar_instructions,
+            spl_token_program,
+            spl_ata_program,
+            authorization_rules_program,
+            authorization_rules,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/mint_new_edition_from_master_edition_via_token.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/mint_new_edition_from_master_edition_via_token.rs
@@ -1,7 +1,6 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
+
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -12,6 +11,7 @@ pub struct MintNewEditionFromMasterEditionViaToken {
         MintNewEditionFromMasterEditionViaTokenArgs,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct MintNewEditionFromMasterEditionViaTokenInstructionAccounts {
     pub new_metadata: solana_pubkey::Pubkey,
     pub new_edition: solana_pubkey::Pubkey,
@@ -26,7 +26,7 @@ pub struct MintNewEditionFromMasterEditionViaTokenInstructionAccounts {
     pub metadata: solana_pubkey::Pubkey,
     pub token_program: solana_pubkey::Pubkey,
     pub system_program: solana_pubkey::Pubkey,
-    pub rent: solana_pubkey::Pubkey,
+    pub rent: Option<solana_pubkey::Pubkey>,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for MintNewEditionFromMasterEditionViaToken {
@@ -35,27 +35,37 @@ impl carbon_core::deserialize::ArrangeAccounts for MintNewEditionFromMasterEditi
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [new_metadata, new_edition, master_edition, new_mint, edition_mark_pda, new_mint_authority, payer, token_account_owner, token_account, new_metadata_update_authority, metadata, token_program, system_program, rent, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let new_metadata = next_account(&mut iter)?;
+        let new_edition = next_account(&mut iter)?;
+        let master_edition = next_account(&mut iter)?;
+        let new_mint = next_account(&mut iter)?;
+        let edition_mark_pda = next_account(&mut iter)?;
+        let new_mint_authority = next_account(&mut iter)?;
+        let payer = next_account(&mut iter)?;
+        let token_account_owner = next_account(&mut iter)?;
+        let token_account = next_account(&mut iter)?;
+        let new_metadata_update_authority = next_account(&mut iter)?;
+        let metadata = next_account(&mut iter)?;
+        let token_program = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let rent = next_account(&mut iter);
 
         Some(MintNewEditionFromMasterEditionViaTokenInstructionAccounts {
-            new_metadata: new_metadata.pubkey,
-            new_edition: new_edition.pubkey,
-            master_edition: master_edition.pubkey,
-            new_mint: new_mint.pubkey,
-            edition_mark_pda: edition_mark_pda.pubkey,
-            new_mint_authority: new_mint_authority.pubkey,
-            payer: payer.pubkey,
-            token_account_owner: token_account_owner.pubkey,
-            token_account: token_account.pubkey,
-            new_metadata_update_authority: new_metadata_update_authority.pubkey,
-            metadata: metadata.pubkey,
-            token_program: token_program.pubkey,
-            system_program: system_program.pubkey,
-            rent: rent.pubkey,
+            new_metadata,
+            new_edition,
+            master_edition,
+            new_mint,
+            edition_mark_pda,
+            new_mint_authority,
+            payer,
+            token_account_owner,
+            token_account,
+            new_metadata_update_authority,
+            metadata,
+            token_program,
+            system_program,
+            rent,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/mint_new_edition_from_master_edition_via_vault_proxy.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/mint_new_edition_from_master_edition_via_vault_proxy.rs
@@ -1,7 +1,6 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
+
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -12,6 +11,7 @@ pub struct MintNewEditionFromMasterEditionViaVaultProxy {
         MintNewEditionFromMasterEditionViaTokenArgs,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct MintNewEditionFromMasterEditionViaVaultProxyInstructionAccounts {
     pub new_metadata: solana_pubkey::Pubkey,
     pub new_edition: solana_pubkey::Pubkey,
@@ -29,7 +29,7 @@ pub struct MintNewEditionFromMasterEditionViaVaultProxyInstructionAccounts {
     pub token_program: solana_pubkey::Pubkey,
     pub token_vault_program: solana_pubkey::Pubkey,
     pub system_program: solana_pubkey::Pubkey,
-    pub rent: solana_pubkey::Pubkey,
+    pub rent: Option<solana_pubkey::Pubkey>,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for MintNewEditionFromMasterEditionViaVaultProxy {
@@ -38,31 +38,44 @@ impl carbon_core::deserialize::ArrangeAccounts for MintNewEditionFromMasterEditi
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [new_metadata, new_edition, master_edition, new_mint, edition_mark_pda, new_mint_authority, payer, vault_authority, safety_deposit_store, safety_deposit_box, vault, new_metadata_update_authority, metadata, token_program, token_vault_program, system_program, rent, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let new_metadata = next_account(&mut iter)?;
+        let new_edition = next_account(&mut iter)?;
+        let master_edition = next_account(&mut iter)?;
+        let new_mint = next_account(&mut iter)?;
+        let edition_mark_pda = next_account(&mut iter)?;
+        let new_mint_authority = next_account(&mut iter)?;
+        let payer = next_account(&mut iter)?;
+        let vault_authority = next_account(&mut iter)?;
+        let safety_deposit_store = next_account(&mut iter)?;
+        let safety_deposit_box = next_account(&mut iter)?;
+        let vault = next_account(&mut iter)?;
+        let new_metadata_update_authority = next_account(&mut iter)?;
+        let metadata = next_account(&mut iter)?;
+        let token_program = next_account(&mut iter)?;
+        let token_vault_program = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let rent = next_account(&mut iter);
 
         Some(
             MintNewEditionFromMasterEditionViaVaultProxyInstructionAccounts {
-                new_metadata: new_metadata.pubkey,
-                new_edition: new_edition.pubkey,
-                master_edition: master_edition.pubkey,
-                new_mint: new_mint.pubkey,
-                edition_mark_pda: edition_mark_pda.pubkey,
-                new_mint_authority: new_mint_authority.pubkey,
-                payer: payer.pubkey,
-                vault_authority: vault_authority.pubkey,
-                safety_deposit_store: safety_deposit_store.pubkey,
-                safety_deposit_box: safety_deposit_box.pubkey,
-                vault: vault.pubkey,
-                new_metadata_update_authority: new_metadata_update_authority.pubkey,
-                metadata: metadata.pubkey,
-                token_program: token_program.pubkey,
-                token_vault_program: token_vault_program.pubkey,
-                system_program: system_program.pubkey,
-                rent: rent.pubkey,
+                new_metadata,
+                new_edition,
+                master_edition,
+                new_mint,
+                edition_mark_pda,
+                new_mint_authority,
+                payer,
+                vault_authority,
+                safety_deposit_store,
+                safety_deposit_box,
+                vault,
+                new_metadata_update_authority,
+                metadata,
+                token_program,
+                token_vault_program,
+                system_program,
+                rent,
             },
         )
     }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/print.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/print.rs
@@ -1,7 +1,6 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
+
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -11,6 +10,7 @@ pub struct Print {
     pub print_args: PrintArgs,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct PrintInstructionAccounts {
     pub edition_metadata: solana_pubkey::Pubkey,
     pub edition: solana_pubkey::Pubkey,
@@ -18,7 +18,7 @@ pub struct PrintInstructionAccounts {
     pub edition_token_account_owner: solana_pubkey::Pubkey,
     pub edition_token_account: solana_pubkey::Pubkey,
     pub edition_mint_authority: solana_pubkey::Pubkey,
-    pub edition_token_record: solana_pubkey::Pubkey,
+    pub edition_token_record: Option<solana_pubkey::Pubkey>,
     pub master_edition: solana_pubkey::Pubkey,
     pub edition_marker_pda: solana_pubkey::Pubkey,
     pub payer: solana_pubkey::Pubkey,
@@ -38,31 +38,45 @@ impl carbon_core::deserialize::ArrangeAccounts for Print {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [edition_metadata, edition, edition_mint, edition_token_account_owner, edition_token_account, edition_mint_authority, edition_token_record, master_edition, edition_marker_pda, payer, master_token_account_owner, master_token_account, master_metadata, update_authority, spl_token_program, spl_ata_program, sysvar_instructions, system_program, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let edition_metadata = next_account(&mut iter)?;
+        let edition = next_account(&mut iter)?;
+        let edition_mint = next_account(&mut iter)?;
+        let edition_token_account_owner = next_account(&mut iter)?;
+        let edition_token_account = next_account(&mut iter)?;
+        let edition_mint_authority = next_account(&mut iter)?;
+        let edition_token_record = next_account(&mut iter);
+        let master_edition = next_account(&mut iter)?;
+        let edition_marker_pda = next_account(&mut iter)?;
+        let payer = next_account(&mut iter)?;
+        let master_token_account_owner = next_account(&mut iter)?;
+        let master_token_account = next_account(&mut iter)?;
+        let master_metadata = next_account(&mut iter)?;
+        let update_authority = next_account(&mut iter)?;
+        let spl_token_program = next_account(&mut iter)?;
+        let spl_ata_program = next_account(&mut iter)?;
+        let sysvar_instructions = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
 
         Some(PrintInstructionAccounts {
-            edition_metadata: edition_metadata.pubkey,
-            edition: edition.pubkey,
-            edition_mint: edition_mint.pubkey,
-            edition_token_account_owner: edition_token_account_owner.pubkey,
-            edition_token_account: edition_token_account.pubkey,
-            edition_mint_authority: edition_mint_authority.pubkey,
-            edition_token_record: edition_token_record.pubkey,
-            master_edition: master_edition.pubkey,
-            edition_marker_pda: edition_marker_pda.pubkey,
-            payer: payer.pubkey,
-            master_token_account_owner: master_token_account_owner.pubkey,
-            master_token_account: master_token_account.pubkey,
-            master_metadata: master_metadata.pubkey,
-            update_authority: update_authority.pubkey,
-            spl_token_program: spl_token_program.pubkey,
-            spl_ata_program: spl_ata_program.pubkey,
-            sysvar_instructions: sysvar_instructions.pubkey,
-            system_program: system_program.pubkey,
+            edition_metadata,
+            edition,
+            edition_mint,
+            edition_token_account_owner,
+            edition_token_account,
+            edition_mint_authority,
+            edition_token_record,
+            master_edition,
+            edition_marker_pda,
+            payer,
+            master_token_account_owner,
+            master_token_account,
+            master_metadata,
+            update_authority,
+            spl_token_program,
+            spl_ata_program,
+            sysvar_instructions,
+            system_program,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/puff_metadata.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/puff_metadata.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,6 +6,7 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x0e")]
 pub struct PuffMetadata {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct PuffMetadataInstructionAccounts {
     pub metadata: solana_pubkey::Pubkey,
 }
@@ -16,12 +17,9 @@ impl carbon_core::deserialize::ArrangeAccounts for PuffMetadata {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [metadata, _remaining @ ..] = accounts else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let metadata = next_account(&mut iter)?;
 
-        Some(PuffMetadataInstructionAccounts {
-            metadata: metadata.pubkey,
-        })
+        Some(PuffMetadataInstructionAccounts { metadata })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/remove_creator_verification.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/remove_creator_verification.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,6 +6,7 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x1c")]
 pub struct RemoveCreatorVerification {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct RemoveCreatorVerificationInstructionAccounts {
     pub metadata: solana_pubkey::Pubkey,
     pub creator: solana_pubkey::Pubkey,
@@ -17,13 +18,10 @@ impl carbon_core::deserialize::ArrangeAccounts for RemoveCreatorVerification {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [metadata, creator, _remaining @ ..] = accounts else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let metadata = next_account(&mut iter)?;
+        let creator = next_account(&mut iter)?;
 
-        Some(RemoveCreatorVerificationInstructionAccounts {
-            metadata: metadata.pubkey,
-            creator: creator.pubkey,
-        })
+        Some(RemoveCreatorVerificationInstructionAccounts { metadata, creator })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/resize.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/resize.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,13 +6,14 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x38")]
 pub struct Resize {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct ResizeInstructionAccounts {
     pub metadata: solana_pubkey::Pubkey,
     pub edition: solana_pubkey::Pubkey,
     pub mint: solana_pubkey::Pubkey,
     pub payer: solana_pubkey::Pubkey,
-    pub authority: solana_pubkey::Pubkey,
-    pub token: solana_pubkey::Pubkey,
+    pub authority: Option<solana_pubkey::Pubkey>,
+    pub token: Option<solana_pubkey::Pubkey>,
     pub system_program: solana_pubkey::Pubkey,
 }
 
@@ -22,20 +23,23 @@ impl carbon_core::deserialize::ArrangeAccounts for Resize {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [metadata, edition, mint, payer, authority, token, system_program, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let metadata = next_account(&mut iter)?;
+        let edition = next_account(&mut iter)?;
+        let mint = next_account(&mut iter)?;
+        let payer = next_account(&mut iter)?;
+        let authority = next_account(&mut iter);
+        let token = next_account(&mut iter);
+        let system_program = next_account(&mut iter)?;
 
         Some(ResizeInstructionAccounts {
-            metadata: metadata.pubkey,
-            edition: edition.pubkey,
-            mint: mint.pubkey,
-            payer: payer.pubkey,
-            authority: authority.pubkey,
-            token: token.pubkey,
-            system_program: system_program.pubkey,
+            metadata,
+            edition,
+            mint,
+            payer,
+            authority,
+            token,
+            system_program,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/revoke.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/revoke.rs
@@ -1,7 +1,6 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
+
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -11,21 +10,22 @@ pub struct Revoke {
     pub revoke_args: RevokeArgs,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct RevokeInstructionAccounts {
-    pub delegate_record: solana_pubkey::Pubkey,
+    pub delegate_record: Option<solana_pubkey::Pubkey>,
     pub delegate: solana_pubkey::Pubkey,
     pub metadata: solana_pubkey::Pubkey,
-    pub master_edition: solana_pubkey::Pubkey,
-    pub token_record: solana_pubkey::Pubkey,
+    pub master_edition: Option<solana_pubkey::Pubkey>,
+    pub token_record: Option<solana_pubkey::Pubkey>,
     pub mint: solana_pubkey::Pubkey,
-    pub token: solana_pubkey::Pubkey,
+    pub token: Option<solana_pubkey::Pubkey>,
     pub authority: solana_pubkey::Pubkey,
     pub payer: solana_pubkey::Pubkey,
     pub system_program: solana_pubkey::Pubkey,
     pub sysvar_instructions: solana_pubkey::Pubkey,
-    pub spl_token_program: solana_pubkey::Pubkey,
-    pub authorization_rules_program: solana_pubkey::Pubkey,
-    pub authorization_rules: solana_pubkey::Pubkey,
+    pub spl_token_program: Option<solana_pubkey::Pubkey>,
+    pub authorization_rules_program: Option<solana_pubkey::Pubkey>,
+    pub authorization_rules: Option<solana_pubkey::Pubkey>,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for Revoke {
@@ -34,27 +34,37 @@ impl carbon_core::deserialize::ArrangeAccounts for Revoke {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [delegate_record, delegate, metadata, master_edition, token_record, mint, token, authority, payer, system_program, sysvar_instructions, spl_token_program, authorization_rules_program, authorization_rules, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let delegate_record = next_account(&mut iter);
+        let delegate = next_account(&mut iter)?;
+        let metadata = next_account(&mut iter)?;
+        let master_edition = next_account(&mut iter);
+        let token_record = next_account(&mut iter);
+        let mint = next_account(&mut iter)?;
+        let token = next_account(&mut iter);
+        let authority = next_account(&mut iter)?;
+        let payer = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let sysvar_instructions = next_account(&mut iter)?;
+        let spl_token_program = next_account(&mut iter);
+        let authorization_rules_program = next_account(&mut iter);
+        let authorization_rules = next_account(&mut iter);
 
         Some(RevokeInstructionAccounts {
-            delegate_record: delegate_record.pubkey,
-            delegate: delegate.pubkey,
-            metadata: metadata.pubkey,
-            master_edition: master_edition.pubkey,
-            token_record: token_record.pubkey,
-            mint: mint.pubkey,
-            token: token.pubkey,
-            authority: authority.pubkey,
-            payer: payer.pubkey,
-            system_program: system_program.pubkey,
-            sysvar_instructions: sysvar_instructions.pubkey,
-            spl_token_program: spl_token_program.pubkey,
-            authorization_rules_program: authorization_rules_program.pubkey,
-            authorization_rules: authorization_rules.pubkey,
+            delegate_record,
+            delegate,
+            metadata,
+            master_edition,
+            token_record,
+            mint,
+            token,
+            authority,
+            payer,
+            system_program,
+            sysvar_instructions,
+            spl_token_program,
+            authorization_rules_program,
+            authorization_rules,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/revoke_collection_authority.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/revoke_collection_authority.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,6 +6,7 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x18")]
 pub struct RevokeCollectionAuthority {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct RevokeCollectionAuthorityInstructionAccounts {
     pub collection_authority_record: solana_pubkey::Pubkey,
     pub delegate_authority: solana_pubkey::Pubkey,
@@ -20,18 +21,19 @@ impl carbon_core::deserialize::ArrangeAccounts for RevokeCollectionAuthority {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [collection_authority_record, delegate_authority, revoke_authority, metadata, mint, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let collection_authority_record = next_account(&mut iter)?;
+        let delegate_authority = next_account(&mut iter)?;
+        let revoke_authority = next_account(&mut iter)?;
+        let metadata = next_account(&mut iter)?;
+        let mint = next_account(&mut iter)?;
 
         Some(RevokeCollectionAuthorityInstructionAccounts {
-            collection_authority_record: collection_authority_record.pubkey,
-            delegate_authority: delegate_authority.pubkey,
-            revoke_authority: revoke_authority.pubkey,
-            metadata: metadata.pubkey,
-            mint: mint.pubkey,
+            collection_authority_record,
+            delegate_authority,
+            revoke_authority,
+            metadata,
+            mint,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/revoke_use_authority.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/revoke_use_authority.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,6 +6,7 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x15")]
 pub struct RevokeUseAuthority {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct RevokeUseAuthorityInstructionAccounts {
     pub use_authority_record: solana_pubkey::Pubkey,
     pub owner: solana_pubkey::Pubkey,
@@ -15,7 +16,7 @@ pub struct RevokeUseAuthorityInstructionAccounts {
     pub metadata: solana_pubkey::Pubkey,
     pub token_program: solana_pubkey::Pubkey,
     pub system_program: solana_pubkey::Pubkey,
-    pub rent: solana_pubkey::Pubkey,
+    pub rent: Option<solana_pubkey::Pubkey>,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for RevokeUseAuthority {
@@ -24,22 +25,27 @@ impl carbon_core::deserialize::ArrangeAccounts for RevokeUseAuthority {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [use_authority_record, owner, user, owner_token_account, mint, metadata, token_program, system_program, rent, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let use_authority_record = next_account(&mut iter)?;
+        let owner = next_account(&mut iter)?;
+        let user = next_account(&mut iter)?;
+        let owner_token_account = next_account(&mut iter)?;
+        let mint = next_account(&mut iter)?;
+        let metadata = next_account(&mut iter)?;
+        let token_program = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let rent = next_account(&mut iter);
 
         Some(RevokeUseAuthorityInstructionAccounts {
-            use_authority_record: use_authority_record.pubkey,
-            owner: owner.pubkey,
-            user: user.pubkey,
-            owner_token_account: owner_token_account.pubkey,
-            mint: mint.pubkey,
-            metadata: metadata.pubkey,
-            token_program: token_program.pubkey,
-            system_program: system_program.pubkey,
-            rent: rent.pubkey,
+            use_authority_record,
+            owner,
+            user,
+            owner_token_account,
+            mint,
+            metadata,
+            token_program,
+            system_program,
+            rent,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/set_and_verify_collection.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/set_and_verify_collection.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,6 +6,7 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x19")]
 pub struct SetAndVerifyCollection {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct SetAndVerifyCollectionInstructionAccounts {
     pub metadata: solana_pubkey::Pubkey,
     pub collection_authority: solana_pubkey::Pubkey,
@@ -14,7 +15,7 @@ pub struct SetAndVerifyCollectionInstructionAccounts {
     pub collection_mint: solana_pubkey::Pubkey,
     pub collection: solana_pubkey::Pubkey,
     pub collection_master_edition_account: solana_pubkey::Pubkey,
-    pub collection_authority_record: solana_pubkey::Pubkey,
+    pub collection_authority_record: Option<solana_pubkey::Pubkey>,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for SetAndVerifyCollection {
@@ -23,21 +24,25 @@ impl carbon_core::deserialize::ArrangeAccounts for SetAndVerifyCollection {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [metadata, collection_authority, payer, update_authority, collection_mint, collection, collection_master_edition_account, collection_authority_record, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let metadata = next_account(&mut iter)?;
+        let collection_authority = next_account(&mut iter)?;
+        let payer = next_account(&mut iter)?;
+        let update_authority = next_account(&mut iter)?;
+        let collection_mint = next_account(&mut iter)?;
+        let collection = next_account(&mut iter)?;
+        let collection_master_edition_account = next_account(&mut iter)?;
+        let collection_authority_record = next_account(&mut iter);
 
         Some(SetAndVerifyCollectionInstructionAccounts {
-            metadata: metadata.pubkey,
-            collection_authority: collection_authority.pubkey,
-            payer: payer.pubkey,
-            update_authority: update_authority.pubkey,
-            collection_mint: collection_mint.pubkey,
-            collection: collection.pubkey,
-            collection_master_edition_account: collection_master_edition_account.pubkey,
-            collection_authority_record: collection_authority_record.pubkey,
+            metadata,
+            collection_authority,
+            payer,
+            update_authority,
+            collection_mint,
+            collection,
+            collection_master_edition_account,
+            collection_authority_record,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/set_and_verify_sized_collection_item.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/set_and_verify_sized_collection_item.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,6 +6,7 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x20")]
 pub struct SetAndVerifySizedCollectionItem {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct SetAndVerifySizedCollectionItemInstructionAccounts {
     pub metadata: solana_pubkey::Pubkey,
     pub collection_authority: solana_pubkey::Pubkey,
@@ -14,7 +15,7 @@ pub struct SetAndVerifySizedCollectionItemInstructionAccounts {
     pub collection_mint: solana_pubkey::Pubkey,
     pub collection: solana_pubkey::Pubkey,
     pub collection_master_edition_account: solana_pubkey::Pubkey,
-    pub collection_authority_record: solana_pubkey::Pubkey,
+    pub collection_authority_record: Option<solana_pubkey::Pubkey>,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for SetAndVerifySizedCollectionItem {
@@ -23,21 +24,25 @@ impl carbon_core::deserialize::ArrangeAccounts for SetAndVerifySizedCollectionIt
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [metadata, collection_authority, payer, update_authority, collection_mint, collection, collection_master_edition_account, collection_authority_record, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let metadata = next_account(&mut iter)?;
+        let collection_authority = next_account(&mut iter)?;
+        let payer = next_account(&mut iter)?;
+        let update_authority = next_account(&mut iter)?;
+        let collection_mint = next_account(&mut iter)?;
+        let collection = next_account(&mut iter)?;
+        let collection_master_edition_account = next_account(&mut iter)?;
+        let collection_authority_record = next_account(&mut iter);
 
         Some(SetAndVerifySizedCollectionItemInstructionAccounts {
-            metadata: metadata.pubkey,
-            collection_authority: collection_authority.pubkey,
-            payer: payer.pubkey,
-            update_authority: update_authority.pubkey,
-            collection_mint: collection_mint.pubkey,
-            collection: collection.pubkey,
-            collection_master_edition_account: collection_master_edition_account.pubkey,
-            collection_authority_record: collection_authority_record.pubkey,
+            metadata,
+            collection_authority,
+            payer,
+            update_authority,
+            collection_mint,
+            collection,
+            collection_master_edition_account,
+            collection_authority_record,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/set_collection_size.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/set_collection_size.rs
@@ -1,7 +1,6 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
+
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -11,11 +10,12 @@ pub struct SetCollectionSize {
     pub set_collection_size_args: SetCollectionSizeArgs,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct SetCollectionSizeInstructionAccounts {
     pub collection_metadata: solana_pubkey::Pubkey,
     pub collection_authority: solana_pubkey::Pubkey,
     pub collection_mint: solana_pubkey::Pubkey,
-    pub collection_authority_record: solana_pubkey::Pubkey,
+    pub collection_authority_record: Option<solana_pubkey::Pubkey>,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for SetCollectionSize {
@@ -24,17 +24,17 @@ impl carbon_core::deserialize::ArrangeAccounts for SetCollectionSize {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [collection_metadata, collection_authority, collection_mint, collection_authority_record, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let collection_metadata = next_account(&mut iter)?;
+        let collection_authority = next_account(&mut iter)?;
+        let collection_mint = next_account(&mut iter)?;
+        let collection_authority_record = next_account(&mut iter);
 
         Some(SetCollectionSizeInstructionAccounts {
-            collection_metadata: collection_metadata.pubkey,
-            collection_authority: collection_authority.pubkey,
-            collection_mint: collection_mint.pubkey,
-            collection_authority_record: collection_authority_record.pubkey,
+            collection_metadata,
+            collection_authority,
+            collection_mint,
+            collection_authority_record,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/set_token_standard.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/set_token_standard.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,11 +6,12 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x23")]
 pub struct SetTokenStandard {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct SetTokenStandardInstructionAccounts {
     pub metadata: solana_pubkey::Pubkey,
     pub update_authority: solana_pubkey::Pubkey,
     pub mint: solana_pubkey::Pubkey,
-    pub edition: solana_pubkey::Pubkey,
+    pub edition: Option<solana_pubkey::Pubkey>,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for SetTokenStandard {
@@ -19,15 +20,17 @@ impl carbon_core::deserialize::ArrangeAccounts for SetTokenStandard {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [metadata, update_authority, mint, edition, _remaining @ ..] = accounts else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let metadata = next_account(&mut iter)?;
+        let update_authority = next_account(&mut iter)?;
+        let mint = next_account(&mut iter)?;
+        let edition = next_account(&mut iter);
 
         Some(SetTokenStandardInstructionAccounts {
-            metadata: metadata.pubkey,
-            update_authority: update_authority.pubkey,
-            mint: mint.pubkey,
-            edition: edition.pubkey,
+            metadata,
+            update_authority,
+            mint,
+            edition,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/sign_metadata.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/sign_metadata.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,6 +6,7 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x07")]
 pub struct SignMetadata {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct SignMetadataInstructionAccounts {
     pub metadata: solana_pubkey::Pubkey,
     pub creator: solana_pubkey::Pubkey,
@@ -17,13 +18,10 @@ impl carbon_core::deserialize::ArrangeAccounts for SignMetadata {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [metadata, creator, _remaining @ ..] = accounts else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let metadata = next_account(&mut iter)?;
+        let creator = next_account(&mut iter)?;
 
-        Some(SignMetadataInstructionAccounts {
-            metadata: metadata.pubkey,
-            creator: creator.pubkey,
-        })
+        Some(SignMetadataInstructionAccounts { metadata, creator })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/thaw_delegated_account.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/thaw_delegated_account.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,6 +6,7 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x1b")]
 pub struct ThawDelegatedAccount {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct ThawDelegatedAccountInstructionAccounts {
     pub delegate: solana_pubkey::Pubkey,
     pub token_account: solana_pubkey::Pubkey,
@@ -20,17 +21,19 @@ impl carbon_core::deserialize::ArrangeAccounts for ThawDelegatedAccount {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [delegate, token_account, edition, mint, token_program, _remaining @ ..] = accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let delegate = next_account(&mut iter)?;
+        let token_account = next_account(&mut iter)?;
+        let edition = next_account(&mut iter)?;
+        let mint = next_account(&mut iter)?;
+        let token_program = next_account(&mut iter)?;
 
         Some(ThawDelegatedAccountInstructionAccounts {
-            delegate: delegate.pubkey,
-            token_account: token_account.pubkey,
-            edition: edition.pubkey,
-            mint: mint.pubkey,
-            token_program: token_program.pubkey,
+            delegate,
+            token_account,
+            edition,
+            mint,
+            token_program,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/transfer.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/transfer.rs
@@ -1,7 +1,6 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
+
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -11,6 +10,7 @@ pub struct Transfer {
     pub transfer_args: TransferArgs,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct TransferInstructionAccounts {
     pub token: solana_pubkey::Pubkey,
     pub token_owner: solana_pubkey::Pubkey,
@@ -18,17 +18,17 @@ pub struct TransferInstructionAccounts {
     pub destination_owner: solana_pubkey::Pubkey,
     pub mint: solana_pubkey::Pubkey,
     pub metadata: solana_pubkey::Pubkey,
-    pub edition: solana_pubkey::Pubkey,
-    pub owner_token_record: solana_pubkey::Pubkey,
-    pub destination_token_record: solana_pubkey::Pubkey,
+    pub edition: Option<solana_pubkey::Pubkey>,
+    pub owner_token_record: Option<solana_pubkey::Pubkey>,
+    pub destination_token_record: Option<solana_pubkey::Pubkey>,
     pub authority: solana_pubkey::Pubkey,
     pub payer: solana_pubkey::Pubkey,
     pub system_program: solana_pubkey::Pubkey,
     pub sysvar_instructions: solana_pubkey::Pubkey,
     pub spl_token_program: solana_pubkey::Pubkey,
     pub spl_ata_program: solana_pubkey::Pubkey,
-    pub authorization_rules_program: solana_pubkey::Pubkey,
-    pub authorization_rules: solana_pubkey::Pubkey,
+    pub authorization_rules_program: Option<solana_pubkey::Pubkey>,
+    pub authorization_rules: Option<solana_pubkey::Pubkey>,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for Transfer {
@@ -37,30 +37,43 @@ impl carbon_core::deserialize::ArrangeAccounts for Transfer {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [token, token_owner, destination, destination_owner, mint, metadata, edition, owner_token_record, destination_token_record, authority, payer, system_program, sysvar_instructions, spl_token_program, spl_ata_program, authorization_rules_program, authorization_rules, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let token = next_account(&mut iter)?;
+        let token_owner = next_account(&mut iter)?;
+        let destination = next_account(&mut iter)?;
+        let destination_owner = next_account(&mut iter)?;
+        let mint = next_account(&mut iter)?;
+        let metadata = next_account(&mut iter)?;
+        let edition = next_account(&mut iter);
+        let owner_token_record = next_account(&mut iter);
+        let destination_token_record = next_account(&mut iter);
+        let authority = next_account(&mut iter)?;
+        let payer = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let sysvar_instructions = next_account(&mut iter)?;
+        let spl_token_program = next_account(&mut iter)?;
+        let spl_ata_program = next_account(&mut iter)?;
+        let authorization_rules_program = next_account(&mut iter);
+        let authorization_rules = next_account(&mut iter);
 
         Some(TransferInstructionAccounts {
-            token: token.pubkey,
-            token_owner: token_owner.pubkey,
-            destination: destination.pubkey,
-            destination_owner: destination_owner.pubkey,
-            mint: mint.pubkey,
-            metadata: metadata.pubkey,
-            edition: edition.pubkey,
-            owner_token_record: owner_token_record.pubkey,
-            destination_token_record: destination_token_record.pubkey,
-            authority: authority.pubkey,
-            payer: payer.pubkey,
-            system_program: system_program.pubkey,
-            sysvar_instructions: sysvar_instructions.pubkey,
-            spl_token_program: spl_token_program.pubkey,
-            spl_ata_program: spl_ata_program.pubkey,
-            authorization_rules_program: authorization_rules_program.pubkey,
-            authorization_rules: authorization_rules.pubkey,
+            token,
+            token_owner,
+            destination,
+            destination_owner,
+            mint,
+            metadata,
+            edition,
+            owner_token_record,
+            destination_token_record,
+            authority,
+            payer,
+            system_program,
+            sysvar_instructions,
+            spl_token_program,
+            spl_ata_program,
+            authorization_rules_program,
+            authorization_rules,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/transfer_out_of_escrow.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/transfer_out_of_escrow.rs
@@ -1,7 +1,6 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
+
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -11,6 +10,7 @@ pub struct TransferOutOfEscrow {
     pub transfer_out_of_escrow_args: TransferOutOfEscrowArgs,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct TransferOutOfEscrowInstructionAccounts {
     pub escrow: solana_pubkey::Pubkey,
     pub metadata: solana_pubkey::Pubkey,
@@ -24,7 +24,7 @@ pub struct TransferOutOfEscrowInstructionAccounts {
     pub ata_program: solana_pubkey::Pubkey,
     pub token_program: solana_pubkey::Pubkey,
     pub sysvar_instructions: solana_pubkey::Pubkey,
-    pub authority: solana_pubkey::Pubkey,
+    pub authority: Option<solana_pubkey::Pubkey>,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for TransferOutOfEscrow {
@@ -33,26 +33,35 @@ impl carbon_core::deserialize::ArrangeAccounts for TransferOutOfEscrow {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [escrow, metadata, payer, attribute_mint, attribute_src, attribute_dst, escrow_mint, escrow_account, system_program, ata_program, token_program, sysvar_instructions, authority, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let escrow = next_account(&mut iter)?;
+        let metadata = next_account(&mut iter)?;
+        let payer = next_account(&mut iter)?;
+        let attribute_mint = next_account(&mut iter)?;
+        let attribute_src = next_account(&mut iter)?;
+        let attribute_dst = next_account(&mut iter)?;
+        let escrow_mint = next_account(&mut iter)?;
+        let escrow_account = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let ata_program = next_account(&mut iter)?;
+        let token_program = next_account(&mut iter)?;
+        let sysvar_instructions = next_account(&mut iter)?;
+        let authority = next_account(&mut iter);
 
         Some(TransferOutOfEscrowInstructionAccounts {
-            escrow: escrow.pubkey,
-            metadata: metadata.pubkey,
-            payer: payer.pubkey,
-            attribute_mint: attribute_mint.pubkey,
-            attribute_src: attribute_src.pubkey,
-            attribute_dst: attribute_dst.pubkey,
-            escrow_mint: escrow_mint.pubkey,
-            escrow_account: escrow_account.pubkey,
-            system_program: system_program.pubkey,
-            ata_program: ata_program.pubkey,
-            token_program: token_program.pubkey,
-            sysvar_instructions: sysvar_instructions.pubkey,
-            authority: authority.pubkey,
+            escrow,
+            metadata,
+            payer,
+            attribute_mint,
+            attribute_src,
+            attribute_dst,
+            escrow_mint,
+            escrow_account,
+            system_program,
+            ata_program,
+            token_program,
+            sysvar_instructions,
+            authority,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/unlock.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/unlock.rs
@@ -1,7 +1,6 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
+
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -11,20 +10,21 @@ pub struct Unlock {
     pub unlock_args: UnlockArgs,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct UnlockInstructionAccounts {
     pub authority: solana_pubkey::Pubkey,
-    pub token_owner: solana_pubkey::Pubkey,
+    pub token_owner: Option<solana_pubkey::Pubkey>,
     pub token: solana_pubkey::Pubkey,
     pub mint: solana_pubkey::Pubkey,
     pub metadata: solana_pubkey::Pubkey,
-    pub edition: solana_pubkey::Pubkey,
-    pub token_record: solana_pubkey::Pubkey,
+    pub edition: Option<solana_pubkey::Pubkey>,
+    pub token_record: Option<solana_pubkey::Pubkey>,
     pub payer: solana_pubkey::Pubkey,
     pub system_program: solana_pubkey::Pubkey,
     pub sysvar_instructions: solana_pubkey::Pubkey,
-    pub spl_token_program: solana_pubkey::Pubkey,
-    pub authorization_rules_program: solana_pubkey::Pubkey,
-    pub authorization_rules: solana_pubkey::Pubkey,
+    pub spl_token_program: Option<solana_pubkey::Pubkey>,
+    pub authorization_rules_program: Option<solana_pubkey::Pubkey>,
+    pub authorization_rules: Option<solana_pubkey::Pubkey>,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for Unlock {
@@ -33,26 +33,35 @@ impl carbon_core::deserialize::ArrangeAccounts for Unlock {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [authority, token_owner, token, mint, metadata, edition, token_record, payer, system_program, sysvar_instructions, spl_token_program, authorization_rules_program, authorization_rules, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let authority = next_account(&mut iter)?;
+        let token_owner = next_account(&mut iter);
+        let token = next_account(&mut iter)?;
+        let mint = next_account(&mut iter)?;
+        let metadata = next_account(&mut iter)?;
+        let edition = next_account(&mut iter);
+        let token_record = next_account(&mut iter);
+        let payer = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let sysvar_instructions = next_account(&mut iter)?;
+        let spl_token_program = next_account(&mut iter);
+        let authorization_rules_program = next_account(&mut iter);
+        let authorization_rules = next_account(&mut iter);
 
         Some(UnlockInstructionAccounts {
-            authority: authority.pubkey,
-            token_owner: token_owner.pubkey,
-            token: token.pubkey,
-            mint: mint.pubkey,
-            metadata: metadata.pubkey,
-            edition: edition.pubkey,
-            token_record: token_record.pubkey,
-            payer: payer.pubkey,
-            system_program: system_program.pubkey,
-            sysvar_instructions: sysvar_instructions.pubkey,
-            spl_token_program: spl_token_program.pubkey,
-            authorization_rules_program: authorization_rules_program.pubkey,
-            authorization_rules: authorization_rules.pubkey,
+            authority,
+            token_owner,
+            token,
+            mint,
+            metadata,
+            edition,
+            token_record,
+            payer,
+            system_program,
+            sysvar_instructions,
+            spl_token_program,
+            authorization_rules_program,
+            authorization_rules,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/unverify.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/unverify.rs
@@ -1,7 +1,6 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
+
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -11,12 +10,13 @@ pub struct Unverify {
     pub verification_args: VerificationArgs,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct UnverifyInstructionAccounts {
     pub authority: solana_pubkey::Pubkey,
-    pub delegate_record: solana_pubkey::Pubkey,
+    pub delegate_record: Option<solana_pubkey::Pubkey>,
     pub metadata: solana_pubkey::Pubkey,
-    pub collection_mint: solana_pubkey::Pubkey,
-    pub collection_metadata: solana_pubkey::Pubkey,
+    pub collection_mint: Option<solana_pubkey::Pubkey>,
+    pub collection_metadata: Option<solana_pubkey::Pubkey>,
     pub system_program: solana_pubkey::Pubkey,
     pub sysvar_instructions: solana_pubkey::Pubkey,
 }
@@ -27,20 +27,23 @@ impl carbon_core::deserialize::ArrangeAccounts for Unverify {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [authority, delegate_record, metadata, collection_mint, collection_metadata, system_program, sysvar_instructions, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let authority = next_account(&mut iter)?;
+        let delegate_record = next_account(&mut iter);
+        let metadata = next_account(&mut iter)?;
+        let collection_mint = next_account(&mut iter);
+        let collection_metadata = next_account(&mut iter);
+        let system_program = next_account(&mut iter)?;
+        let sysvar_instructions = next_account(&mut iter)?;
 
         Some(UnverifyInstructionAccounts {
-            authority: authority.pubkey,
-            delegate_record: delegate_record.pubkey,
-            metadata: metadata.pubkey,
-            collection_mint: collection_mint.pubkey,
-            collection_metadata: collection_metadata.pubkey,
-            system_program: system_program.pubkey,
-            sysvar_instructions: sysvar_instructions.pubkey,
+            authority,
+            delegate_record,
+            metadata,
+            collection_mint,
+            collection_metadata,
+            system_program,
+            sysvar_instructions,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/unverify_collection.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/unverify_collection.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,13 +6,14 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x16")]
 pub struct UnverifyCollection {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct UnverifyCollectionInstructionAccounts {
     pub metadata: solana_pubkey::Pubkey,
     pub collection_authority: solana_pubkey::Pubkey,
     pub collection_mint: solana_pubkey::Pubkey,
     pub collection: solana_pubkey::Pubkey,
     pub collection_master_edition_account: solana_pubkey::Pubkey,
-    pub collection_authority_record: solana_pubkey::Pubkey,
+    pub collection_authority_record: Option<solana_pubkey::Pubkey>,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for UnverifyCollection {
@@ -21,19 +22,21 @@ impl carbon_core::deserialize::ArrangeAccounts for UnverifyCollection {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [metadata, collection_authority, collection_mint, collection, collection_master_edition_account, collection_authority_record, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let metadata = next_account(&mut iter)?;
+        let collection_authority = next_account(&mut iter)?;
+        let collection_mint = next_account(&mut iter)?;
+        let collection = next_account(&mut iter)?;
+        let collection_master_edition_account = next_account(&mut iter)?;
+        let collection_authority_record = next_account(&mut iter);
 
         Some(UnverifyCollectionInstructionAccounts {
-            metadata: metadata.pubkey,
-            collection_authority: collection_authority.pubkey,
-            collection_mint: collection_mint.pubkey,
-            collection: collection.pubkey,
-            collection_master_edition_account: collection_master_edition_account.pubkey,
-            collection_authority_record: collection_authority_record.pubkey,
+            metadata,
+            collection_authority,
+            collection_mint,
+            collection,
+            collection_master_edition_account,
+            collection_authority_record,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/unverify_sized_collection_item.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/unverify_sized_collection_item.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,6 +6,7 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x1f")]
 pub struct UnverifySizedCollectionItem {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct UnverifySizedCollectionItemInstructionAccounts {
     pub metadata: solana_pubkey::Pubkey,
     pub collection_authority: solana_pubkey::Pubkey,
@@ -13,7 +14,7 @@ pub struct UnverifySizedCollectionItemInstructionAccounts {
     pub collection_mint: solana_pubkey::Pubkey,
     pub collection: solana_pubkey::Pubkey,
     pub collection_master_edition_account: solana_pubkey::Pubkey,
-    pub collection_authority_record: solana_pubkey::Pubkey,
+    pub collection_authority_record: Option<solana_pubkey::Pubkey>,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for UnverifySizedCollectionItem {
@@ -22,20 +23,23 @@ impl carbon_core::deserialize::ArrangeAccounts for UnverifySizedCollectionItem {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [metadata, collection_authority, payer, collection_mint, collection, collection_master_edition_account, collection_authority_record, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let metadata = next_account(&mut iter)?;
+        let collection_authority = next_account(&mut iter)?;
+        let payer = next_account(&mut iter)?;
+        let collection_mint = next_account(&mut iter)?;
+        let collection = next_account(&mut iter)?;
+        let collection_master_edition_account = next_account(&mut iter)?;
+        let collection_authority_record = next_account(&mut iter);
 
         Some(UnverifySizedCollectionItemInstructionAccounts {
-            metadata: metadata.pubkey,
-            collection_authority: collection_authority.pubkey,
-            payer: payer.pubkey,
-            collection_mint: collection_mint.pubkey,
-            collection: collection.pubkey,
-            collection_master_edition_account: collection_master_edition_account.pubkey,
-            collection_authority_record: collection_authority_record.pubkey,
+            metadata,
+            collection_authority,
+            payer,
+            collection_mint,
+            collection,
+            collection_master_edition_account,
+            collection_authority_record,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/update.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/update.rs
@@ -1,7 +1,6 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
+
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -11,18 +10,19 @@ pub struct Update {
     pub update_args: UpdateArgs,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct UpdateInstructionAccounts {
     pub authority: solana_pubkey::Pubkey,
-    pub delegate_record: solana_pubkey::Pubkey,
-    pub token: solana_pubkey::Pubkey,
+    pub delegate_record: Option<solana_pubkey::Pubkey>,
+    pub token: Option<solana_pubkey::Pubkey>,
     pub mint: solana_pubkey::Pubkey,
     pub metadata: solana_pubkey::Pubkey,
-    pub edition: solana_pubkey::Pubkey,
+    pub edition: Option<solana_pubkey::Pubkey>,
     pub payer: solana_pubkey::Pubkey,
     pub system_program: solana_pubkey::Pubkey,
     pub sysvar_instructions: solana_pubkey::Pubkey,
-    pub authorization_rules_program: solana_pubkey::Pubkey,
-    pub authorization_rules: solana_pubkey::Pubkey,
+    pub authorization_rules_program: Option<solana_pubkey::Pubkey>,
+    pub authorization_rules: Option<solana_pubkey::Pubkey>,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for Update {
@@ -31,24 +31,31 @@ impl carbon_core::deserialize::ArrangeAccounts for Update {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [authority, delegate_record, token, mint, metadata, edition, payer, system_program, sysvar_instructions, authorization_rules_program, authorization_rules, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let authority = next_account(&mut iter)?;
+        let delegate_record = next_account(&mut iter);
+        let token = next_account(&mut iter);
+        let mint = next_account(&mut iter)?;
+        let metadata = next_account(&mut iter)?;
+        let edition = next_account(&mut iter);
+        let payer = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let sysvar_instructions = next_account(&mut iter)?;
+        let authorization_rules_program = next_account(&mut iter);
+        let authorization_rules = next_account(&mut iter);
 
         Some(UpdateInstructionAccounts {
-            authority: authority.pubkey,
-            delegate_record: delegate_record.pubkey,
-            token: token.pubkey,
-            mint: mint.pubkey,
-            metadata: metadata.pubkey,
-            edition: edition.pubkey,
-            payer: payer.pubkey,
-            system_program: system_program.pubkey,
-            sysvar_instructions: sysvar_instructions.pubkey,
-            authorization_rules_program: authorization_rules_program.pubkey,
-            authorization_rules: authorization_rules.pubkey,
+            authority,
+            delegate_record,
+            token,
+            mint,
+            metadata,
+            edition,
+            payer,
+            system_program,
+            sysvar_instructions,
+            authorization_rules_program,
+            authorization_rules,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/update_metadata_account.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/update_metadata_account.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,6 +6,7 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x01")]
 pub struct UpdateMetadataAccount {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct UpdateMetadataAccountInstructionAccounts {
     pub metadata: solana_pubkey::Pubkey,
     pub update_authority: solana_pubkey::Pubkey,
@@ -17,13 +18,13 @@ impl carbon_core::deserialize::ArrangeAccounts for UpdateMetadataAccount {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [metadata, update_authority, _remaining @ ..] = accounts else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let metadata = next_account(&mut iter)?;
+        let update_authority = next_account(&mut iter)?;
 
         Some(UpdateMetadataAccountInstructionAccounts {
-            metadata: metadata.pubkey,
-            update_authority: update_authority.pubkey,
+            metadata,
+            update_authority,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/update_metadata_account_v2.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/update_metadata_account_v2.rs
@@ -1,7 +1,6 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
+
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -11,6 +10,7 @@ pub struct UpdateMetadataAccountV2 {
     pub update_metadata_account_args_v2: UpdateMetadataAccountArgsV2,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct UpdateMetadataAccountV2InstructionAccounts {
     pub metadata: solana_pubkey::Pubkey,
     pub update_authority: solana_pubkey::Pubkey,
@@ -22,13 +22,13 @@ impl carbon_core::deserialize::ArrangeAccounts for UpdateMetadataAccountV2 {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [metadata, update_authority, _remaining @ ..] = accounts else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let metadata = next_account(&mut iter)?;
+        let update_authority = next_account(&mut iter)?;
 
         Some(UpdateMetadataAccountV2InstructionAccounts {
-            metadata: metadata.pubkey,
-            update_authority: update_authority.pubkey,
+            metadata,
+            update_authority,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/update_primary_sale_happened_via_token.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/update_primary_sale_happened_via_token.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,6 +6,7 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x04")]
 pub struct UpdatePrimarySaleHappenedViaToken {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct UpdatePrimarySaleHappenedViaTokenInstructionAccounts {
     pub metadata: solana_pubkey::Pubkey,
     pub owner: solana_pubkey::Pubkey,
@@ -18,14 +19,15 @@ impl carbon_core::deserialize::ArrangeAccounts for UpdatePrimarySaleHappenedViaT
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [metadata, owner, token, _remaining @ ..] = accounts else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let metadata = next_account(&mut iter)?;
+        let owner = next_account(&mut iter)?;
+        let token = next_account(&mut iter)?;
 
         Some(UpdatePrimarySaleHappenedViaTokenInstructionAccounts {
-            metadata: metadata.pubkey,
-            owner: owner.pubkey,
-            token: token.pubkey,
+            metadata,
+            owner,
+            token,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/utilize.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/utilize.rs
@@ -1,7 +1,6 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
+
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -11,6 +10,7 @@ pub struct Utilize {
     pub utilize_args: UtilizeArgs,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct UtilizeInstructionAccounts {
     pub metadata: solana_pubkey::Pubkey,
     pub token_account: solana_pubkey::Pubkey,
@@ -21,8 +21,8 @@ pub struct UtilizeInstructionAccounts {
     pub ata_program: solana_pubkey::Pubkey,
     pub system_program: solana_pubkey::Pubkey,
     pub rent: solana_pubkey::Pubkey,
-    pub use_authority_record: solana_pubkey::Pubkey,
-    pub burner: solana_pubkey::Pubkey,
+    pub use_authority_record: Option<solana_pubkey::Pubkey>,
+    pub burner: Option<solana_pubkey::Pubkey>,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for Utilize {
@@ -31,24 +31,31 @@ impl carbon_core::deserialize::ArrangeAccounts for Utilize {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [metadata, token_account, mint, use_authority, owner, token_program, ata_program, system_program, rent, use_authority_record, burner, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let metadata = next_account(&mut iter)?;
+        let token_account = next_account(&mut iter)?;
+        let mint = next_account(&mut iter)?;
+        let use_authority = next_account(&mut iter)?;
+        let owner = next_account(&mut iter)?;
+        let token_program = next_account(&mut iter)?;
+        let ata_program = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let rent = next_account(&mut iter)?;
+        let use_authority_record = next_account(&mut iter);
+        let burner = next_account(&mut iter);
 
         Some(UtilizeInstructionAccounts {
-            metadata: metadata.pubkey,
-            token_account: token_account.pubkey,
-            mint: mint.pubkey,
-            use_authority: use_authority.pubkey,
-            owner: owner.pubkey,
-            token_program: token_program.pubkey,
-            ata_program: ata_program.pubkey,
-            system_program: system_program.pubkey,
-            rent: rent.pubkey,
-            use_authority_record: use_authority_record.pubkey,
-            burner: burner.pubkey,
+            metadata,
+            token_account,
+            mint,
+            use_authority,
+            owner,
+            token_program,
+            ata_program,
+            system_program,
+            rent,
+            use_authority_record,
+            burner,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/verify.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/verify.rs
@@ -1,7 +1,6 @@
-use {
-    super::super::types::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::super::types::*;
+
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -11,13 +10,14 @@ pub struct Verify {
     pub verification_args: VerificationArgs,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct VerifyInstructionAccounts {
     pub authority: solana_pubkey::Pubkey,
-    pub delegate_record: solana_pubkey::Pubkey,
+    pub delegate_record: Option<solana_pubkey::Pubkey>,
     pub metadata: solana_pubkey::Pubkey,
-    pub collection_mint: solana_pubkey::Pubkey,
-    pub collection_metadata: solana_pubkey::Pubkey,
-    pub collection_master_edition: solana_pubkey::Pubkey,
+    pub collection_mint: Option<solana_pubkey::Pubkey>,
+    pub collection_metadata: Option<solana_pubkey::Pubkey>,
+    pub collection_master_edition: Option<solana_pubkey::Pubkey>,
     pub system_program: solana_pubkey::Pubkey,
     pub sysvar_instructions: solana_pubkey::Pubkey,
 }
@@ -28,21 +28,25 @@ impl carbon_core::deserialize::ArrangeAccounts for Verify {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [authority, delegate_record, metadata, collection_mint, collection_metadata, collection_master_edition, system_program, sysvar_instructions, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let authority = next_account(&mut iter)?;
+        let delegate_record = next_account(&mut iter);
+        let metadata = next_account(&mut iter)?;
+        let collection_mint = next_account(&mut iter);
+        let collection_metadata = next_account(&mut iter);
+        let collection_master_edition = next_account(&mut iter);
+        let system_program = next_account(&mut iter)?;
+        let sysvar_instructions = next_account(&mut iter)?;
 
         Some(VerifyInstructionAccounts {
-            authority: authority.pubkey,
-            delegate_record: delegate_record.pubkey,
-            metadata: metadata.pubkey,
-            collection_mint: collection_mint.pubkey,
-            collection_metadata: collection_metadata.pubkey,
-            collection_master_edition: collection_master_edition.pubkey,
-            system_program: system_program.pubkey,
-            sysvar_instructions: sysvar_instructions.pubkey,
+            authority,
+            delegate_record,
+            metadata,
+            collection_mint,
+            collection_metadata,
+            collection_master_edition,
+            system_program,
+            sysvar_instructions,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/verify_collection.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/verify_collection.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,6 +6,7 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x12")]
 pub struct VerifyCollection {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct VerifyCollectionInstructionAccounts {
     pub metadata: solana_pubkey::Pubkey,
     pub collection_authority: solana_pubkey::Pubkey,
@@ -13,7 +14,7 @@ pub struct VerifyCollectionInstructionAccounts {
     pub collection_mint: solana_pubkey::Pubkey,
     pub collection: solana_pubkey::Pubkey,
     pub collection_master_edition_account: solana_pubkey::Pubkey,
-    pub collection_authority_record: solana_pubkey::Pubkey,
+    pub collection_authority_record: Option<solana_pubkey::Pubkey>,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for VerifyCollection {
@@ -22,20 +23,23 @@ impl carbon_core::deserialize::ArrangeAccounts for VerifyCollection {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [metadata, collection_authority, payer, collection_mint, collection, collection_master_edition_account, collection_authority_record, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let metadata = next_account(&mut iter)?;
+        let collection_authority = next_account(&mut iter)?;
+        let payer = next_account(&mut iter)?;
+        let collection_mint = next_account(&mut iter)?;
+        let collection = next_account(&mut iter)?;
+        let collection_master_edition_account = next_account(&mut iter)?;
+        let collection_authority_record = next_account(&mut iter);
 
         Some(VerifyCollectionInstructionAccounts {
-            metadata: metadata.pubkey,
-            collection_authority: collection_authority.pubkey,
-            payer: payer.pubkey,
-            collection_mint: collection_mint.pubkey,
-            collection: collection.pubkey,
-            collection_master_edition_account: collection_master_edition_account.pubkey,
-            collection_authority_record: collection_authority_record.pubkey,
+            metadata,
+            collection_authority,
+            payer,
+            collection_mint,
+            collection,
+            collection_master_edition_account,
+            collection_authority_record,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/instructions/verify_sized_collection_item.rs
+++ b/decoders/mpl-token-metadata-decoder/src/instructions/verify_sized_collection_item.rs
@@ -1,4 +1,4 @@
-use carbon_core::{borsh, CarbonDeserialize};
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
@@ -6,6 +6,7 @@ use carbon_core::{borsh, CarbonDeserialize};
 #[carbon(discriminator = "0x1e")]
 pub struct VerifySizedCollectionItem {}
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct VerifySizedCollectionItemInstructionAccounts {
     pub metadata: solana_pubkey::Pubkey,
     pub collection_authority: solana_pubkey::Pubkey,
@@ -13,7 +14,7 @@ pub struct VerifySizedCollectionItemInstructionAccounts {
     pub collection_mint: solana_pubkey::Pubkey,
     pub collection: solana_pubkey::Pubkey,
     pub collection_master_edition_account: solana_pubkey::Pubkey,
-    pub collection_authority_record: solana_pubkey::Pubkey,
+    pub collection_authority_record: Option<solana_pubkey::Pubkey>,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for VerifySizedCollectionItem {
@@ -22,20 +23,23 @@ impl carbon_core::deserialize::ArrangeAccounts for VerifySizedCollectionItem {
     fn arrange_accounts(
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
-        let [metadata, collection_authority, payer, collection_mint, collection, collection_master_edition_account, collection_authority_record, _remaining @ ..] =
-            accounts
-        else {
-            return None;
-        };
+        let mut iter = accounts.iter();
+        let metadata = next_account(&mut iter)?;
+        let collection_authority = next_account(&mut iter)?;
+        let payer = next_account(&mut iter)?;
+        let collection_mint = next_account(&mut iter)?;
+        let collection = next_account(&mut iter)?;
+        let collection_master_edition_account = next_account(&mut iter)?;
+        let collection_authority_record = next_account(&mut iter);
 
         Some(VerifySizedCollectionItemInstructionAccounts {
-            metadata: metadata.pubkey,
-            collection_authority: collection_authority.pubkey,
-            payer: payer.pubkey,
-            collection_mint: collection_mint.pubkey,
-            collection: collection.pubkey,
-            collection_master_edition_account: collection_master_edition_account.pubkey,
-            collection_authority_record: collection_authority_record.pubkey,
+            metadata,
+            collection_authority,
+            payer,
+            collection_mint,
+            collection,
+            collection_master_edition_account,
+            collection_authority_record,
         })
     }
 }

--- a/decoders/mpl-token-metadata-decoder/src/types/asset_data.rs
+++ b/decoders/mpl-token-metadata-decoder/src/types/asset_data.rs
@@ -1,7 +1,6 @@
-use {
-    super::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::*;
+
+use carbon_core::{borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,

--- a/decoders/mpl-token-metadata-decoder/src/types/authorization_data.rs
+++ b/decoders/mpl-token-metadata-decoder/src/types/authorization_data.rs
@@ -1,7 +1,6 @@
-use {
-    super::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::*;
+
+use carbon_core::{borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,

--- a/decoders/mpl-token-metadata-decoder/src/types/collection_details_toggle.rs
+++ b/decoders/mpl-token-metadata-decoder/src/types/collection_details_toggle.rs
@@ -1,7 +1,6 @@
-use {
-    super::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::*;
+
+use carbon_core::{borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,

--- a/decoders/mpl-token-metadata-decoder/src/types/collection_toggle.rs
+++ b/decoders/mpl-token-metadata-decoder/src/types/collection_toggle.rs
@@ -1,7 +1,6 @@
-use {
-    super::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::*;
+
+use carbon_core::{borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,

--- a/decoders/mpl-token-metadata-decoder/src/types/create_args.rs
+++ b/decoders/mpl-token-metadata-decoder/src/types/create_args.rs
@@ -1,7 +1,6 @@
-use {
-    super::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::*;
+
+use carbon_core::{borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,

--- a/decoders/mpl-token-metadata-decoder/src/types/create_metadata_account_args_v3.rs
+++ b/decoders/mpl-token-metadata-decoder/src/types/create_metadata_account_args_v3.rs
@@ -1,7 +1,6 @@
-use {
-    super::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::*;
+
+use carbon_core::{borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,

--- a/decoders/mpl-token-metadata-decoder/src/types/data.rs
+++ b/decoders/mpl-token-metadata-decoder/src/types/data.rs
@@ -1,7 +1,6 @@
-use {
-    super::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::*;
+
+use carbon_core::{borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,

--- a/decoders/mpl-token-metadata-decoder/src/types/data_v2.rs
+++ b/decoders/mpl-token-metadata-decoder/src/types/data_v2.rs
@@ -1,7 +1,6 @@
-use {
-    super::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::*;
+
+use carbon_core::{borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,

--- a/decoders/mpl-token-metadata-decoder/src/types/delegate_args.rs
+++ b/decoders/mpl-token-metadata-decoder/src/types/delegate_args.rs
@@ -1,7 +1,6 @@
-use {
-    super::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::*;
+
+use carbon_core::{borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,

--- a/decoders/mpl-token-metadata-decoder/src/types/lock_args.rs
+++ b/decoders/mpl-token-metadata-decoder/src/types/lock_args.rs
@@ -1,7 +1,6 @@
-use {
-    super::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::*;
+
+use carbon_core::{borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,

--- a/decoders/mpl-token-metadata-decoder/src/types/mint_args.rs
+++ b/decoders/mpl-token-metadata-decoder/src/types/mint_args.rs
@@ -1,7 +1,6 @@
-use {
-    super::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::*;
+
+use carbon_core::{borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,

--- a/decoders/mpl-token-metadata-decoder/src/types/payload_type.rs
+++ b/decoders/mpl-token-metadata-decoder/src/types/payload_type.rs
@@ -1,7 +1,6 @@
-use {
-    super::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::*;
+
+use carbon_core::{borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,

--- a/decoders/mpl-token-metadata-decoder/src/types/transfer_args.rs
+++ b/decoders/mpl-token-metadata-decoder/src/types/transfer_args.rs
@@ -1,7 +1,6 @@
-use {
-    super::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::*;
+
+use carbon_core::{borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,

--- a/decoders/mpl-token-metadata-decoder/src/types/unlock_args.rs
+++ b/decoders/mpl-token-metadata-decoder/src/types/unlock_args.rs
@@ -1,7 +1,6 @@
-use {
-    super::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::*;
+
+use carbon_core::{borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,

--- a/decoders/mpl-token-metadata-decoder/src/types/update_args.rs
+++ b/decoders/mpl-token-metadata-decoder/src/types/update_args.rs
@@ -1,7 +1,6 @@
-use {
-    super::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::*;
+
+use carbon_core::{borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,

--- a/decoders/mpl-token-metadata-decoder/src/types/update_metadata_account_args_v2.rs
+++ b/decoders/mpl-token-metadata-decoder/src/types/update_metadata_account_args_v2.rs
@@ -1,7 +1,6 @@
-use {
-    super::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::*;
+
+use carbon_core::{borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,

--- a/decoders/mpl-token-metadata-decoder/src/types/use_args.rs
+++ b/decoders/mpl-token-metadata-decoder/src/types/use_args.rs
@@ -1,7 +1,6 @@
-use {
-    super::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::*;
+
+use carbon_core::{borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,

--- a/decoders/mpl-token-metadata-decoder/src/types/uses.rs
+++ b/decoders/mpl-token-metadata-decoder/src/types/uses.rs
@@ -1,7 +1,6 @@
-use {
-    super::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::*;
+
+use carbon_core::{borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,

--- a/decoders/mpl-token-metadata-decoder/src/types/uses_toggle.rs
+++ b/decoders/mpl-token-metadata-decoder/src/types/uses_toggle.rs
@@ -1,7 +1,6 @@
-use {
-    super::*,
-    carbon_core::{borsh, CarbonDeserialize},
-};
+use super::*;
+
+use carbon_core::{borsh, CarbonDeserialize};
 
 #[derive(
     CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,

--- a/decoders/mpl-token-metadata-decoder/tests/fixtures/README.md
+++ b/decoders/mpl-token-metadata-decoder/tests/fixtures/README.md
@@ -1,0 +1,5 @@
+# MPL Token Metadata Tests
+
+## Instructions
+
+-[CreateMetadataV3](https://solscan.io/tx/4srDKje7jmxauwMdh1mduVDAfWccqmJjiFZ78ZZXr1fwpQifsN3Dm8d5NrxtYfhFfu164VoomCAqct4abRYffp4L)

--- a/decoders/mpl-token-metadata-decoder/tests/fixtures/create_metadata_v3_ix.json
+++ b/decoders/mpl-token-metadata-decoder/tests/fixtures/create_metadata_v3_ix.json
@@ -1,0 +1,37 @@
+{
+    "program_id": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s",
+    "accounts": [
+        {
+            "pubkey": "FURfzvnjVPdjrfMBRzeSgahzS1xietCqiv8SG9pCS8ke",
+            "is_signer": false,
+            "is_writable": true
+        },
+        {
+            "pubkey": "A3p836DWHzDA3DY73QfJSLCqekkhGohNXVAHAa1Qbonk",
+            "is_signer": true,
+            "is_writable": true
+        },
+        {
+            "pubkey": "WLHv2UAZm6z4KyaaELi5pjdbJh6RESMva1Rnn8pJVVh",
+            "is_signer": false,
+            "is_writable": false
+        },
+        {
+            "pubkey": "5f5BPCCNeMkekfjFZi18kAYU95rRdM2jToGaNZZwYZX6",
+            "is_signer": true,
+            "is_writable": true
+        },
+        {
+            "pubkey": "WLHv2UAZm6z4KyaaELi5pjdbJh6RESMva1Rnn8pJVVh",
+            "is_signer": false,
+            "is_writable": false
+        },
+        {
+            "pubkey": "11111111111111111111111111111111",
+            "is_signer": false,
+            "is_writable": false
+        }
+    ],
+    "data": "210c000000e382b9e382ade382bae383bc05000000534b5a4f4f5000000068747470733a2f2f697066732e696f2f697066732f6261666b72656967777573626171793763676268336d76696a3567753463326d346d736163656f757470773566796973797079636837676c7a6a6d000001010000000783a81526210f94a0e8e84d2087003b3a4260d29ce79dacfe21a4ea771fa628016400000000",
+    "signature": "4srDKje7jmxauwMdh1mduVDAfWccqmJjiFZ78ZZXr1fwpQifsN3Dm8d5NrxtYfhFfu164VoomCAqct4abRYffp4L"
+}


### PR DESCRIPTION
1. Support for generating decoders with optional accounts, it considers 3 cases:
 - Optional account in middle: These are used with `PROGRAM_ID` as placeholders to skip, can be omitted on user end.
 - Optional accounts in the end: Accounts like `Rent` are omitted in some transactions and crashes indexer.
 - Optional accounts marked with `optional` ([In Legacy IDL](https://github.com/metaplex-foundation/mpl-token-metadata/blob/main/programs/token-metadata/js/idl/mpl_token_metadata.json)) and `IsOptional`
 
 2. Added `next_account` in `account_utils` for common utility functions.
 
 3. Generated MPL Token Metadata decoder with latest [IDL v1.14](https://github.com/metaplex-foundation/mpl-token-metadata/blob/main/idls/token_metadata.json)
 
4. Add tests in `mpl-token-metadata-decoder` for optional `rent` account in Instruction `CreateMetadataV3`.

fixes #334 