### PR TITLE
feat: add meteora vault decoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,6 +1544,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "carbon-meteora-vault-decoder"
+version = "0.1.0"
+dependencies = [
+ "carbon-core",
+ "serde",
+ "solana-account",
+ "solana-instruction",
+ "solana-pubkey",
+]
+
+[[package]]
 name = "carbon-moonshot-decoder"
 version = "0.9.1"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-meteora-vault-decoder"
-version = "0.1.0"
+version = "0.9.1"
 dependencies = [
  "carbon-core",
  "serde",

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ Decoders for most popular Solana programs are published and maintained:
 | `carbon-meteora-damm-v2-decoder`           | Meteora DAMM V2 Program Decoder           | cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG  |
 | `carbon-meteora-dlmm-decoder`              | Meteora DLMM Program Decoder              | LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo  |
 | `carbon-meteora-pools-decoder`             | Meteora Pools Program Decoder             | Eo7WjKq67rjJQSZxS6z3YkapzY3eMj6Xy8X5EQVn5UaB |
+| `carbon-meteora-vault-decoder`             | Meteora Vault Program Decoder             | 24Uqj9JCLxUeoC3hGfh5W3s9FM9uCHDS2SG3LYwBpyTi |
 | `carbon-moonshot-decoder`                  | Moonshot Program Decoder                  | MoonCVVNZFSYkqNXP6bxHLPL6QQJiMagDL3qcqUQTrG  |
 | `carbon-mpl-core-decoder`                  | MPL Core Program Decoder                  | CoREENxT6tW1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7d |
 | `carbon-mpl-token-metadata-decoder`        | MPL Token Metadata Program Decoder        | metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s  |

--- a/decoders/meteora-vault-decoder/Cargo.toml
+++ b/decoders/meteora-vault-decoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "carbon-meteora-vault-decoder"
-version = "0.1.0"
+version = "0.9.1"
 description = "Meteora vault program decoder"
 edition = { workspace = true }
 license = { workspace = true }

--- a/decoders/meteora-vault-decoder/Cargo.toml
+++ b/decoders/meteora-vault-decoder/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "carbon-meteora-vault-decoder"
+version = "0.1.0"
+description = "Meteora vault program decoder"
+edition = { workspace = true }
+license = { workspace = true }
+readme = "README.md"
+keywords = ["solana", "decoder", "meteora"]
+categories = ["encoding"]
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+carbon-core = { workspace = true }
+serde = { workspace = true }
+solana-account = { workspace = true }
+solana-instruction = { workspace = true, default-features = false }
+solana-pubkey = { workspace = true }

--- a/decoders/meteora-vault-decoder/README.md
+++ b/decoders/meteora-vault-decoder/README.md
@@ -1,0 +1,1 @@
+# Carbon Meteora Vault Program Decoder

--- a/decoders/meteora-vault-decoder/src/accounts/mod.rs
+++ b/decoders/meteora-vault-decoder/src/accounts/mod.rs
@@ -1,0 +1,47 @@
+use {
+    super::MeteoraVaultDecoder,
+    crate::PROGRAM_ID,
+    carbon_core::{account::AccountDecoder, deserialize::CarbonDeserialize},
+};
+pub mod strategy;
+pub mod vault;
+
+#[allow(clippy::large_enum_variant)]
+pub enum MeteoraVaultAccount {
+    Vault(vault::Vault),
+    Strategy(strategy::Strategy),
+}
+
+impl AccountDecoder<'_> for MeteoraVaultDecoder {
+    type AccountType = MeteoraVaultAccount;
+    fn decode_account(
+        &self,
+        account: &solana_account::Account,
+    ) -> Option<carbon_core::account::DecodedAccount<Self::AccountType>> {
+        if !account.owner.eq(&PROGRAM_ID) {
+            return None;
+        }
+
+        if let Some(decoded_account) = vault::Vault::deserialize(account.data.as_slice()) {
+            return Some(carbon_core::account::DecodedAccount {
+                lamports: account.lamports,
+                data: MeteoraVaultAccount::Vault(decoded_account),
+                owner: account.owner,
+                executable: account.executable,
+                rent_epoch: account.rent_epoch,
+            });
+        }
+
+        if let Some(decoded_account) = strategy::Strategy::deserialize(account.data.as_slice()) {
+            return Some(carbon_core::account::DecodedAccount {
+                lamports: account.lamports,
+                data: MeteoraVaultAccount::Strategy(decoded_account),
+                owner: account.owner,
+                executable: account.executable,
+                rent_epoch: account.rent_epoch,
+            });
+        }
+
+        None
+    }
+}

--- a/decoders/meteora-vault-decoder/src/accounts/strategy.rs
+++ b/decoders/meteora-vault-decoder/src/accounts/strategy.rs
@@ -1,0 +1,17 @@
+use super::super::types::*;
+
+use carbon_core::{borsh, CarbonDeserialize};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xae6e2777526aa966")]
+pub struct Strategy {
+    pub reserve: solana_pubkey::Pubkey,
+    pub collateral_vault: solana_pubkey::Pubkey,
+    pub strategy_type: StrategyType,
+    pub current_liquidity: u64,
+    pub bumps: [u8; 10],
+    pub vault: solana_pubkey::Pubkey,
+    pub is_disable: u8,
+}

--- a/decoders/meteora-vault-decoder/src/accounts/vault.rs
+++ b/decoders/meteora-vault-decoder/src/accounts/vault.rs
@@ -1,0 +1,22 @@
+use super::super::types::*;
+
+use carbon_core::{borsh, CarbonDeserialize};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xd308e82b02987577")]
+pub struct Vault {
+    pub enabled: u8,
+    pub bumps: VaultBumps,
+    pub total_amount: u64,
+    pub token_vault: solana_pubkey::Pubkey,
+    pub fee_vault: solana_pubkey::Pubkey,
+    pub token_mint: solana_pubkey::Pubkey,
+    pub lp_mint: solana_pubkey::Pubkey,
+    pub strategies: [solana_pubkey::Pubkey; 30],
+    pub base: solana_pubkey::Pubkey,
+    pub admin: solana_pubkey::Pubkey,
+    pub operator: solana_pubkey::Pubkey,
+    pub locked_profit_tracker: LockedProfitTracker,
+}

--- a/decoders/meteora-vault-decoder/src/instructions/add_liquidity_event.rs
+++ b/decoders/meteora-vault-decoder/src/instructions/add_liquidity_event.rs
@@ -1,0 +1,10 @@
+use carbon_core::{borsh, CarbonDeserialize};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xe445a52e51cb9a1d1f5e7d5ae3343dba")]
+pub struct AddLiquidityEvent {
+    pub lp_mint_amount: u64,
+    pub token_amount: u64,
+}

--- a/decoders/meteora-vault-decoder/src/instructions/add_strategy.rs
+++ b/decoders/meteora-vault-decoder/src/instructions/add_strategy.rs
@@ -1,0 +1,33 @@
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0x407b7fe3c0eac614")]
+pub struct AddStrategy {}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct AddStrategyInstructionAccounts {
+    pub vault: solana_pubkey::Pubkey,
+    pub strategy: solana_pubkey::Pubkey,
+    pub admin: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for AddStrategy {
+    type ArrangedAccounts = AddStrategyInstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let vault = next_account(&mut iter)?;
+        let strategy = next_account(&mut iter)?;
+        let admin = next_account(&mut iter)?;
+
+        Some(AddStrategyInstructionAccounts {
+            vault,
+            strategy,
+            admin,
+        })
+    }
+}

--- a/decoders/meteora-vault-decoder/src/instructions/claim_reward_event.rs
+++ b/decoders/meteora-vault-decoder/src/instructions/claim_reward_event.rs
@@ -1,0 +1,13 @@
+use super::super::types::*;
+
+use carbon_core::{borsh, CarbonDeserialize};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xe445a52e51cb9a1d947486cc16ab555f")]
+pub struct ClaimRewardEvent {
+    pub strategy_type: StrategyType,
+    pub token_amount: u64,
+    pub mint_account: solana_pubkey::Pubkey,
+}

--- a/decoders/meteora-vault-decoder/src/instructions/collect_dust.rs
+++ b/decoders/meteora-vault-decoder/src/instructions/collect_dust.rs
@@ -1,0 +1,39 @@
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xf6951552a04afef0")]
+pub struct CollectDust {}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct CollectDustInstructionAccounts {
+    pub vault: solana_pubkey::Pubkey,
+    pub token_vault: solana_pubkey::Pubkey,
+    pub token_admin: solana_pubkey::Pubkey,
+    pub admin: solana_pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for CollectDust {
+    type ArrangedAccounts = CollectDustInstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let vault = next_account(&mut iter)?;
+        let token_vault = next_account(&mut iter)?;
+        let token_admin = next_account(&mut iter)?;
+        let admin = next_account(&mut iter)?;
+        let token_program = next_account(&mut iter)?;
+
+        Some(CollectDustInstructionAccounts {
+            vault,
+            token_vault,
+            token_admin,
+            admin,
+            token_program,
+        })
+    }
+}

--- a/decoders/meteora-vault-decoder/src/instructions/deposit.rs
+++ b/decoders/meteora-vault-decoder/src/instructions/deposit.rs
@@ -1,0 +1,48 @@
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xf223c68952e1f2b6")]
+pub struct Deposit {
+    pub token_amount: u64,
+    pub minimum_lp_token_amount: u64,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct DepositInstructionAccounts {
+    pub vault: solana_pubkey::Pubkey,
+    pub token_vault: solana_pubkey::Pubkey,
+    pub lp_mint: solana_pubkey::Pubkey,
+    pub user_token: solana_pubkey::Pubkey,
+    pub user_lp: solana_pubkey::Pubkey,
+    pub user: solana_pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for Deposit {
+    type ArrangedAccounts = DepositInstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let vault = next_account(&mut iter)?;
+        let token_vault = next_account(&mut iter)?;
+        let lp_mint = next_account(&mut iter)?;
+        let user_token = next_account(&mut iter)?;
+        let user_lp = next_account(&mut iter)?;
+        let user = next_account(&mut iter)?;
+        let token_program = next_account(&mut iter)?;
+
+        Some(DepositInstructionAccounts {
+            vault,
+            token_vault,
+            lp_mint,
+            user_token,
+            user_lp,
+            user,
+            token_program,
+        })
+    }
+}

--- a/decoders/meteora-vault-decoder/src/instructions/deposit_strategy.rs
+++ b/decoders/meteora-vault-decoder/src/instructions/deposit_strategy.rs
@@ -1,0 +1,56 @@
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xf65239e283defdf9")]
+pub struct DepositStrategy {
+    pub amount: u64,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct DepositStrategyInstructionAccounts {
+    pub vault: solana_pubkey::Pubkey,
+    pub strategy: solana_pubkey::Pubkey,
+    pub token_vault: solana_pubkey::Pubkey,
+    pub fee_vault: solana_pubkey::Pubkey,
+    pub lp_mint: solana_pubkey::Pubkey,
+    pub strategy_program: solana_pubkey::Pubkey,
+    pub collateral_vault: solana_pubkey::Pubkey,
+    pub reserve: solana_pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
+    pub operator: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for DepositStrategy {
+    type ArrangedAccounts = DepositStrategyInstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let vault = next_account(&mut iter)?;
+        let strategy = next_account(&mut iter)?;
+        let token_vault = next_account(&mut iter)?;
+        let fee_vault = next_account(&mut iter)?;
+        let lp_mint = next_account(&mut iter)?;
+        let strategy_program = next_account(&mut iter)?;
+        let collateral_vault = next_account(&mut iter)?;
+        let reserve = next_account(&mut iter)?;
+        let token_program = next_account(&mut iter)?;
+        let operator = next_account(&mut iter)?;
+
+        Some(DepositStrategyInstructionAccounts {
+            vault,
+            strategy,
+            token_vault,
+            fee_vault,
+            lp_mint,
+            strategy_program,
+            collateral_vault,
+            reserve,
+            token_program,
+            operator,
+        })
+    }
+}

--- a/decoders/meteora-vault-decoder/src/instructions/enable_vault.rs
+++ b/decoders/meteora-vault-decoder/src/instructions/enable_vault.rs
@@ -1,0 +1,29 @@
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0x9152f19c1a9ae9d3")]
+pub struct EnableVault {
+    pub enabled: u8,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct EnableVaultInstructionAccounts {
+    pub vault: solana_pubkey::Pubkey,
+    pub admin: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for EnableVault {
+    type ArrangedAccounts = EnableVaultInstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let vault = next_account(&mut iter)?;
+        let admin = next_account(&mut iter)?;
+
+        Some(EnableVaultInstructionAccounts { vault, admin })
+    }
+}

--- a/decoders/meteora-vault-decoder/src/instructions/initialize.rs
+++ b/decoders/meteora-vault-decoder/src/instructions/initialize.rs
@@ -1,0 +1,48 @@
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xafaf6d1f0d989bed")]
+pub struct Initialize {}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct InitializeInstructionAccounts {
+    pub vault: solana_pubkey::Pubkey,
+    pub payer: solana_pubkey::Pubkey,
+    pub token_vault: solana_pubkey::Pubkey,
+    pub token_mint: solana_pubkey::Pubkey,
+    pub lp_mint: solana_pubkey::Pubkey,
+    pub rent: solana_pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for Initialize {
+    type ArrangedAccounts = InitializeInstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let vault = next_account(&mut iter)?;
+        let payer = next_account(&mut iter)?;
+        let token_vault = next_account(&mut iter)?;
+        let token_mint = next_account(&mut iter)?;
+        let lp_mint = next_account(&mut iter)?;
+        let rent = next_account(&mut iter)?;
+        let token_program = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+
+        Some(InitializeInstructionAccounts {
+            vault,
+            payer,
+            token_vault,
+            token_mint,
+            lp_mint,
+            rent,
+            token_program,
+            system_program,
+        })
+    }
+}

--- a/decoders/meteora-vault-decoder/src/instructions/initialize_strategy.rs
+++ b/decoders/meteora-vault-decoder/src/instructions/initialize_strategy.rs
@@ -1,0 +1,59 @@
+use super::super::types::*;
+
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xd0779091b23969fc")]
+pub struct InitializeStrategy {
+    pub bumps: StrategyBumps,
+    pub strategy_type: StrategyType,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct InitializeStrategyInstructionAccounts {
+    pub vault: solana_pubkey::Pubkey,
+    pub strategy_program: solana_pubkey::Pubkey,
+    pub strategy: solana_pubkey::Pubkey,
+    pub reserve: solana_pubkey::Pubkey,
+    pub collateral_vault: solana_pubkey::Pubkey,
+    pub collateral_mint: solana_pubkey::Pubkey,
+    pub admin: solana_pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
+    pub rent: solana_pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for InitializeStrategy {
+    type ArrangedAccounts = InitializeStrategyInstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let vault = next_account(&mut iter)?;
+        let strategy_program = next_account(&mut iter)?;
+        let strategy = next_account(&mut iter)?;
+        let reserve = next_account(&mut iter)?;
+        let collateral_vault = next_account(&mut iter)?;
+        let collateral_mint = next_account(&mut iter)?;
+        let admin = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let rent = next_account(&mut iter)?;
+        let token_program = next_account(&mut iter)?;
+
+        Some(InitializeStrategyInstructionAccounts {
+            vault,
+            strategy_program,
+            strategy,
+            reserve,
+            collateral_vault,
+            collateral_mint,
+            admin,
+            system_program,
+            rent,
+            token_program,
+        })
+    }
+}

--- a/decoders/meteora-vault-decoder/src/instructions/mod.rs
+++ b/decoders/meteora-vault-decoder/src/instructions/mod.rs
@@ -1,0 +1,98 @@
+use crate::PROGRAM_ID;
+
+use super::MeteoraVaultDecoder;
+pub mod add_liquidity_event;
+pub mod add_strategy;
+pub mod claim_reward_event;
+pub mod collect_dust;
+pub mod deposit;
+pub mod deposit_strategy;
+pub mod enable_vault;
+pub mod initialize;
+pub mod initialize_strategy;
+pub mod performance_fee_event;
+pub mod remove_liquidity_event;
+pub mod remove_strategy;
+pub mod remove_strategy2;
+pub mod report_loss_event;
+pub mod set_operator;
+pub mod strategy_deposit_event;
+pub mod strategy_withdraw_event;
+pub mod total_amount_event;
+pub mod withdraw;
+pub mod withdraw2;
+pub mod withdraw_directly_from_strategy;
+pub mod withdraw_strategy;
+
+#[derive(
+    carbon_core::InstructionType,
+    serde::Serialize,
+    serde::Deserialize,
+    PartialEq,
+    Eq,
+    Debug,
+    Clone,
+    Hash,
+)]
+pub enum MeteoraVaultInstruction {
+    Initialize(initialize::Initialize),
+    EnableVault(enable_vault::EnableVault),
+    SetOperator(set_operator::SetOperator),
+    InitializeStrategy(initialize_strategy::InitializeStrategy),
+    RemoveStrategy(remove_strategy::RemoveStrategy),
+    RemoveStrategy2(remove_strategy2::RemoveStrategy2),
+    CollectDust(collect_dust::CollectDust),
+    AddStrategy(add_strategy::AddStrategy),
+    DepositStrategy(deposit_strategy::DepositStrategy),
+    WithdrawStrategy(withdraw_strategy::WithdrawStrategy),
+    Withdraw2(withdraw2::Withdraw2),
+    Deposit(deposit::Deposit),
+    Withdraw(withdraw::Withdraw),
+    WithdrawDirectlyFromStrategy(withdraw_directly_from_strategy::WithdrawDirectlyFromStrategy),
+    AddLiquidityEvent(add_liquidity_event::AddLiquidityEvent),
+    RemoveLiquidityEvent(remove_liquidity_event::RemoveLiquidityEvent),
+    StrategyDepositEvent(strategy_deposit_event::StrategyDepositEvent),
+    StrategyWithdrawEvent(strategy_withdraw_event::StrategyWithdrawEvent),
+    ClaimRewardEvent(claim_reward_event::ClaimRewardEvent),
+    PerformanceFeeEvent(performance_fee_event::PerformanceFeeEvent),
+    ReportLossEvent(report_loss_event::ReportLossEvent),
+    TotalAmountEvent(total_amount_event::TotalAmountEvent),
+}
+
+impl carbon_core::instruction::InstructionDecoder<'_> for MeteoraVaultDecoder {
+    type InstructionType = MeteoraVaultInstruction;
+
+    fn decode_instruction(
+        &self,
+        instruction: &solana_instruction::Instruction,
+    ) -> Option<carbon_core::instruction::DecodedInstruction<Self::InstructionType>> {
+        if !instruction.program_id.eq(&PROGRAM_ID) {
+            return None;
+        }
+
+        carbon_core::try_decode_instructions!(instruction,
+            MeteoraVaultInstruction::Initialize => initialize::Initialize,
+            MeteoraVaultInstruction::EnableVault => enable_vault::EnableVault,
+            MeteoraVaultInstruction::SetOperator => set_operator::SetOperator,
+            MeteoraVaultInstruction::InitializeStrategy => initialize_strategy::InitializeStrategy,
+            MeteoraVaultInstruction::RemoveStrategy => remove_strategy::RemoveStrategy,
+            MeteoraVaultInstruction::RemoveStrategy2 => remove_strategy2::RemoveStrategy2,
+            MeteoraVaultInstruction::CollectDust => collect_dust::CollectDust,
+            MeteoraVaultInstruction::AddStrategy => add_strategy::AddStrategy,
+            MeteoraVaultInstruction::DepositStrategy => deposit_strategy::DepositStrategy,
+            MeteoraVaultInstruction::WithdrawStrategy => withdraw_strategy::WithdrawStrategy,
+            MeteoraVaultInstruction::Withdraw2 => withdraw2::Withdraw2,
+            MeteoraVaultInstruction::Deposit => deposit::Deposit,
+            MeteoraVaultInstruction::Withdraw => withdraw::Withdraw,
+            MeteoraVaultInstruction::WithdrawDirectlyFromStrategy => withdraw_directly_from_strategy::WithdrawDirectlyFromStrategy,
+            MeteoraVaultInstruction::AddLiquidityEvent => add_liquidity_event::AddLiquidityEvent,
+            MeteoraVaultInstruction::RemoveLiquidityEvent => remove_liquidity_event::RemoveLiquidityEvent,
+            MeteoraVaultInstruction::StrategyDepositEvent => strategy_deposit_event::StrategyDepositEvent,
+            MeteoraVaultInstruction::StrategyWithdrawEvent => strategy_withdraw_event::StrategyWithdrawEvent,
+            MeteoraVaultInstruction::ClaimRewardEvent => claim_reward_event::ClaimRewardEvent,
+            MeteoraVaultInstruction::PerformanceFeeEvent => performance_fee_event::PerformanceFeeEvent,
+            MeteoraVaultInstruction::ReportLossEvent => report_loss_event::ReportLossEvent,
+            MeteoraVaultInstruction::TotalAmountEvent => total_amount_event::TotalAmountEvent,
+        )
+    }
+}

--- a/decoders/meteora-vault-decoder/src/instructions/performance_fee_event.rs
+++ b/decoders/meteora-vault-decoder/src/instructions/performance_fee_event.rs
@@ -1,0 +1,9 @@
+use carbon_core::{borsh, CarbonDeserialize};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xe445a52e51cb9a1d1c46e7df516defa7")]
+pub struct PerformanceFeeEvent {
+    pub lp_mint_more: u64,
+}

--- a/decoders/meteora-vault-decoder/src/instructions/remove_liquidity_event.rs
+++ b/decoders/meteora-vault-decoder/src/instructions/remove_liquidity_event.rs
@@ -1,0 +1,10 @@
+use carbon_core::{borsh, CarbonDeserialize};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xe445a52e51cb9a1d74f461e8671f983a")]
+pub struct RemoveLiquidityEvent {
+    pub lp_unmint_amount: u64,
+    pub token_amount: u64,
+}

--- a/decoders/meteora-vault-decoder/src/instructions/remove_strategy.rs
+++ b/decoders/meteora-vault-decoder/src/instructions/remove_strategy.rs
@@ -1,0 +1,54 @@
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xb9ee215b86d2611a")]
+pub struct RemoveStrategy {}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct RemoveStrategyInstructionAccounts {
+    pub vault: solana_pubkey::Pubkey,
+    pub strategy: solana_pubkey::Pubkey,
+    pub strategy_program: solana_pubkey::Pubkey,
+    pub collateral_vault: solana_pubkey::Pubkey,
+    pub reserve: solana_pubkey::Pubkey,
+    pub token_vault: solana_pubkey::Pubkey,
+    pub fee_vault: solana_pubkey::Pubkey,
+    pub lp_mint: solana_pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
+    pub admin: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for RemoveStrategy {
+    type ArrangedAccounts = RemoveStrategyInstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let vault = next_account(&mut iter)?;
+        let strategy = next_account(&mut iter)?;
+        let strategy_program = next_account(&mut iter)?;
+        let collateral_vault = next_account(&mut iter)?;
+        let reserve = next_account(&mut iter)?;
+        let token_vault = next_account(&mut iter)?;
+        let fee_vault = next_account(&mut iter)?;
+        let lp_mint = next_account(&mut iter)?;
+        let token_program = next_account(&mut iter)?;
+        let admin = next_account(&mut iter)?;
+
+        Some(RemoveStrategyInstructionAccounts {
+            vault,
+            strategy,
+            strategy_program,
+            collateral_vault,
+            reserve,
+            token_vault,
+            fee_vault,
+            lp_mint,
+            token_program,
+            admin,
+        })
+    }
+}

--- a/decoders/meteora-vault-decoder/src/instructions/remove_strategy2.rs
+++ b/decoders/meteora-vault-decoder/src/instructions/remove_strategy2.rs
@@ -1,0 +1,62 @@
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0x8a68d0947e23c30e")]
+pub struct RemoveStrategy2 {
+    pub max_admin_pay_amount: u64,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct RemoveStrategy2InstructionAccounts {
+    pub vault: solana_pubkey::Pubkey,
+    pub strategy: solana_pubkey::Pubkey,
+    pub strategy_program: solana_pubkey::Pubkey,
+    pub collateral_vault: solana_pubkey::Pubkey,
+    pub reserve: solana_pubkey::Pubkey,
+    pub token_vault: solana_pubkey::Pubkey,
+    pub token_admin_advance_payment: solana_pubkey::Pubkey,
+    pub token_vault_advance_payment: solana_pubkey::Pubkey,
+    pub fee_vault: solana_pubkey::Pubkey,
+    pub lp_mint: solana_pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
+    pub admin: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for RemoveStrategy2 {
+    type ArrangedAccounts = RemoveStrategy2InstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let vault = next_account(&mut iter)?;
+        let strategy = next_account(&mut iter)?;
+        let strategy_program = next_account(&mut iter)?;
+        let collateral_vault = next_account(&mut iter)?;
+        let reserve = next_account(&mut iter)?;
+        let token_vault = next_account(&mut iter)?;
+        let token_admin_advance_payment = next_account(&mut iter)?;
+        let token_vault_advance_payment = next_account(&mut iter)?;
+        let fee_vault = next_account(&mut iter)?;
+        let lp_mint = next_account(&mut iter)?;
+        let token_program = next_account(&mut iter)?;
+        let admin = next_account(&mut iter)?;
+
+        Some(RemoveStrategy2InstructionAccounts {
+            vault,
+            strategy,
+            strategy_program,
+            collateral_vault,
+            reserve,
+            token_vault,
+            token_admin_advance_payment,
+            token_vault_advance_payment,
+            fee_vault,
+            lp_mint,
+            token_program,
+            admin,
+        })
+    }
+}

--- a/decoders/meteora-vault-decoder/src/instructions/report_loss_event.rs
+++ b/decoders/meteora-vault-decoder/src/instructions/report_loss_event.rs
@@ -1,0 +1,10 @@
+use carbon_core::{borsh, CarbonDeserialize};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xe445a52e51cb9a1d9a249ec420a37b7e")]
+pub struct ReportLossEvent {
+    pub strategy: solana_pubkey::Pubkey,
+    pub loss: u64,
+}

--- a/decoders/meteora-vault-decoder/src/instructions/set_operator.rs
+++ b/decoders/meteora-vault-decoder/src/instructions/set_operator.rs
@@ -1,0 +1,33 @@
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xee9965a9f3832401")]
+pub struct SetOperator {}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct SetOperatorInstructionAccounts {
+    pub vault: solana_pubkey::Pubkey,
+    pub operator: solana_pubkey::Pubkey,
+    pub admin: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for SetOperator {
+    type ArrangedAccounts = SetOperatorInstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let vault = next_account(&mut iter)?;
+        let operator = next_account(&mut iter)?;
+        let admin = next_account(&mut iter)?;
+
+        Some(SetOperatorInstructionAccounts {
+            vault,
+            operator,
+            admin,
+        })
+    }
+}

--- a/decoders/meteora-vault-decoder/src/instructions/strategy_deposit_event.rs
+++ b/decoders/meteora-vault-decoder/src/instructions/strategy_deposit_event.rs
@@ -1,0 +1,12 @@
+use super::super::types::*;
+
+use carbon_core::{borsh, CarbonDeserialize};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xe445a52e51cb9a1dcd355bef2288492f")]
+pub struct StrategyDepositEvent {
+    pub strategy_type: StrategyType,
+    pub token_amount: u64,
+}

--- a/decoders/meteora-vault-decoder/src/instructions/strategy_withdraw_event.rs
+++ b/decoders/meteora-vault-decoder/src/instructions/strategy_withdraw_event.rs
@@ -1,0 +1,13 @@
+use super::super::types::*;
+
+use carbon_core::{borsh, CarbonDeserialize};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xe445a52e51cb9a1d784cd05fddd2e5bd")]
+pub struct StrategyWithdrawEvent {
+    pub strategy_type: StrategyType,
+    pub collateral_amount: u64,
+    pub estimated_token_amount: u64,
+}

--- a/decoders/meteora-vault-decoder/src/instructions/total_amount_event.rs
+++ b/decoders/meteora-vault-decoder/src/instructions/total_amount_event.rs
@@ -1,0 +1,9 @@
+use carbon_core::{borsh, CarbonDeserialize};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xe445a52e51cb9a1d5cc87a91d3cb31cd")]
+pub struct TotalAmountEvent {
+    pub total_amount: u64,
+}

--- a/decoders/meteora-vault-decoder/src/instructions/withdraw.rs
+++ b/decoders/meteora-vault-decoder/src/instructions/withdraw.rs
@@ -1,0 +1,48 @@
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xb712469c946da122")]
+pub struct Withdraw {
+    pub unmint_amount: u64,
+    pub min_out_amount: u64,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct WithdrawInstructionAccounts {
+    pub vault: solana_pubkey::Pubkey,
+    pub token_vault: solana_pubkey::Pubkey,
+    pub lp_mint: solana_pubkey::Pubkey,
+    pub user_token: solana_pubkey::Pubkey,
+    pub user_lp: solana_pubkey::Pubkey,
+    pub user: solana_pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for Withdraw {
+    type ArrangedAccounts = WithdrawInstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let vault = next_account(&mut iter)?;
+        let token_vault = next_account(&mut iter)?;
+        let lp_mint = next_account(&mut iter)?;
+        let user_token = next_account(&mut iter)?;
+        let user_lp = next_account(&mut iter)?;
+        let user = next_account(&mut iter)?;
+        let token_program = next_account(&mut iter)?;
+
+        Some(WithdrawInstructionAccounts {
+            vault,
+            token_vault,
+            lp_mint,
+            user_token,
+            user_lp,
+            user,
+            token_program,
+        })
+    }
+}

--- a/decoders/meteora-vault-decoder/src/instructions/withdraw2.rs
+++ b/decoders/meteora-vault-decoder/src/instructions/withdraw2.rs
@@ -1,0 +1,48 @@
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0x50066f49aed34284")]
+pub struct Withdraw2 {
+    pub unmint_amount: u64,
+    pub min_out_amount: u64,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct Withdraw2InstructionAccounts {
+    pub vault: solana_pubkey::Pubkey,
+    pub token_vault: solana_pubkey::Pubkey,
+    pub lp_mint: solana_pubkey::Pubkey,
+    pub user_token: solana_pubkey::Pubkey,
+    pub user_lp: solana_pubkey::Pubkey,
+    pub user: solana_pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for Withdraw2 {
+    type ArrangedAccounts = Withdraw2InstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let vault = next_account(&mut iter)?;
+        let token_vault = next_account(&mut iter)?;
+        let lp_mint = next_account(&mut iter)?;
+        let user_token = next_account(&mut iter)?;
+        let user_lp = next_account(&mut iter)?;
+        let user = next_account(&mut iter)?;
+        let token_program = next_account(&mut iter)?;
+
+        Some(Withdraw2InstructionAccounts {
+            vault,
+            token_vault,
+            lp_mint,
+            user_token,
+            user_lp,
+            user,
+            token_program,
+        })
+    }
+}

--- a/decoders/meteora-vault-decoder/src/instructions/withdraw_directly_from_strategy.rs
+++ b/decoders/meteora-vault-decoder/src/instructions/withdraw_directly_from_strategy.rs
@@ -1,0 +1,63 @@
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xc98d922ead74c616")]
+pub struct WithdrawDirectlyFromStrategy {
+    pub unmint_amount: u64,
+    pub min_out_amount: u64,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct WithdrawDirectlyFromStrategyInstructionAccounts {
+    pub vault: solana_pubkey::Pubkey,
+    pub strategy: solana_pubkey::Pubkey,
+    pub reserve: solana_pubkey::Pubkey,
+    pub strategy_program: solana_pubkey::Pubkey,
+    pub collateral_vault: solana_pubkey::Pubkey,
+    pub token_vault: solana_pubkey::Pubkey,
+    pub lp_mint: solana_pubkey::Pubkey,
+    pub fee_vault: solana_pubkey::Pubkey,
+    pub user_token: solana_pubkey::Pubkey,
+    pub user_lp: solana_pubkey::Pubkey,
+    pub user: solana_pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for WithdrawDirectlyFromStrategy {
+    type ArrangedAccounts = WithdrawDirectlyFromStrategyInstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let vault = next_account(&mut iter)?;
+        let strategy = next_account(&mut iter)?;
+        let reserve = next_account(&mut iter)?;
+        let strategy_program = next_account(&mut iter)?;
+        let collateral_vault = next_account(&mut iter)?;
+        let token_vault = next_account(&mut iter)?;
+        let lp_mint = next_account(&mut iter)?;
+        let fee_vault = next_account(&mut iter)?;
+        let user_token = next_account(&mut iter)?;
+        let user_lp = next_account(&mut iter)?;
+        let user = next_account(&mut iter)?;
+        let token_program = next_account(&mut iter)?;
+
+        Some(WithdrawDirectlyFromStrategyInstructionAccounts {
+            vault,
+            strategy,
+            reserve,
+            strategy_program,
+            collateral_vault,
+            token_vault,
+            lp_mint,
+            fee_vault,
+            user_token,
+            user_lp,
+            user,
+            token_program,
+        })
+    }
+}

--- a/decoders/meteora-vault-decoder/src/instructions/withdraw_strategy.rs
+++ b/decoders/meteora-vault-decoder/src/instructions/withdraw_strategy.rs
@@ -1,0 +1,56 @@
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0x1f2da205c1d986bc")]
+pub struct WithdrawStrategy {
+    pub amount: u64,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct WithdrawStrategyInstructionAccounts {
+    pub vault: solana_pubkey::Pubkey,
+    pub strategy: solana_pubkey::Pubkey,
+    pub token_vault: solana_pubkey::Pubkey,
+    pub fee_vault: solana_pubkey::Pubkey,
+    pub lp_mint: solana_pubkey::Pubkey,
+    pub strategy_program: solana_pubkey::Pubkey,
+    pub collateral_vault: solana_pubkey::Pubkey,
+    pub reserve: solana_pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
+    pub operator: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for WithdrawStrategy {
+    type ArrangedAccounts = WithdrawStrategyInstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let vault = next_account(&mut iter)?;
+        let strategy = next_account(&mut iter)?;
+        let token_vault = next_account(&mut iter)?;
+        let fee_vault = next_account(&mut iter)?;
+        let lp_mint = next_account(&mut iter)?;
+        let strategy_program = next_account(&mut iter)?;
+        let collateral_vault = next_account(&mut iter)?;
+        let reserve = next_account(&mut iter)?;
+        let token_program = next_account(&mut iter)?;
+        let operator = next_account(&mut iter)?;
+
+        Some(WithdrawStrategyInstructionAccounts {
+            vault,
+            strategy,
+            token_vault,
+            fee_vault,
+            lp_mint,
+            strategy_program,
+            collateral_vault,
+            reserve,
+            token_program,
+            operator,
+        })
+    }
+}

--- a/decoders/meteora-vault-decoder/src/lib.rs
+++ b/decoders/meteora-vault-decoder/src/lib.rs
@@ -1,0 +1,10 @@
+use solana_pubkey::Pubkey;
+
+pub struct MeteoraVaultDecoder;
+
+pub mod accounts;
+pub mod instructions;
+pub mod types;
+
+pub const PROGRAM_ID: Pubkey =
+    Pubkey::from_str_const("24Uqj9JCLxUeoC3hGfh5W3s9FM9uCHDS2SG3LYwBpyTi");

--- a/decoders/meteora-vault-decoder/src/types/locked_profit_tracker.rs
+++ b/decoders/meteora-vault-decoder/src/types/locked_profit_tracker.rs
@@ -1,0 +1,10 @@
+use carbon_core::{borsh, CarbonDeserialize};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+pub struct LockedProfitTracker {
+    pub last_updated_locked_profit: u64,
+    pub last_report: u64,
+    pub locked_profit_degradation: u64,
+}

--- a/decoders/meteora-vault-decoder/src/types/mod.rs
+++ b/decoders/meteora-vault-decoder/src/types/mod.rs
@@ -1,0 +1,8 @@
+pub mod vault_bumps;
+pub use vault_bumps::*;
+pub mod strategy_bumps;
+pub use strategy_bumps::*;
+pub mod locked_profit_tracker;
+pub use locked_profit_tracker::*;
+pub mod strategy_type;
+pub use strategy_type::*;

--- a/decoders/meteora-vault-decoder/src/types/strategy_bumps.rs
+++ b/decoders/meteora-vault-decoder/src/types/strategy_bumps.rs
@@ -1,0 +1,9 @@
+use carbon_core::{borsh, CarbonDeserialize};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+pub struct StrategyBumps {
+    pub strategy_index: u8,
+    pub other_bumps: [u8; 10],
+}

--- a/decoders/meteora-vault-decoder/src/types/strategy_type.rs
+++ b/decoders/meteora-vault-decoder/src/types/strategy_type.rs
@@ -1,0 +1,19 @@
+use carbon_core::{borsh, CarbonDeserialize};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+pub enum StrategyType {
+    PortFinanceWithoutLM,
+    PortFinanceWithLM,
+    SolendWithoutLM,
+    Mango,
+    SolendWithLM,
+    ApricotWithoutLM,
+    Francium,
+    Tulip,
+    Vault,
+    Drift,
+    Frakt,
+    Marginfi,
+}

--- a/decoders/meteora-vault-decoder/src/types/vault_bumps.rs
+++ b/decoders/meteora-vault-decoder/src/types/vault_bumps.rs
@@ -1,0 +1,9 @@
+use carbon_core::{borsh, CarbonDeserialize};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+pub struct VaultBumps {
+    pub vault_bump: u8,
+    pub token_vault_bump: u8,
+}

--- a/scripts/publish-crate.sh
+++ b/scripts/publish-crate.sh
@@ -45,6 +45,7 @@ workspace_crates=(
     carbon-meteora-damm-v2-decoder
     carbon-meteora-dlmm-decoder
     carbon-meteora-pools-decoder
+    carbon-meteora-vault-decoder
     carbon-meteora-dbc-decoder
     carbon-moonshot-decoder
     carbon-mpl-core-decoder


### PR DESCRIPTION
On commit e605efb used command:

carbon-cli parse --idl 24Uqj9JCLxUeoC3hGfh5W3s9FM9uCHDS2SG3LYwBpyTi -u mainnet-beta

to create decoder.