### PR TITLE
docs: add example for arch linux package install

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ chmod +x carbon-cli-linux-amd64
 sudo mv carbon-cli-linux-amd64 /usr/local/bin/carbon-cli
 ```
 
+###### Arch Linux AUR [package](https://aur.archlinux.org/packages/carbon-cli)
+
+```sh
+paru carbon-cli
+```
+
 ##### macOS
 
 ```sh


### PR DESCRIPTION
Add example to README.md to install carbon-cli via AUR [package](https://aur.archlinux.org/packages/carbon-cli)