### PR TITLE
Fixed filter in `decode_log_events()`

### DIFF
--- a/crates/core/src/instruction.rs
+++ b/crates/core/src/instruction.rs
@@ -83,7 +83,7 @@ impl InstructionMetadata {
         self.extract_event_log_data()
             .into_iter()
             .filter(|log| log.len() >= 8)
-            .filter_map(|log| <T as CarbonDeserialize>::deserialize(&log[8..]))
+            .filter_map(|log| <T as CarbonDeserialize>::deserialize(&log))
             .collect()
     }
 


### PR DESCRIPTION
This PR resolves the issue #446

@dougEfresh, since you've already seen the problem, I'd appreciate it if you'd review and merge this.
I left both filters, as you have adviced.