### PR TITLE
fix:Carbon CLI

### DIFF
--- a/packages/renderer/src/getRenderMapVisitor.ts
+++ b/packages/renderer/src/getRenderMapVisitor.ts
@@ -437,12 +437,12 @@ export function getRenderMapVisitor(options: GetRenderMapOptions = {}) {
                     if (accountsToExport.length > 0) {
                         map.add('src/accounts/mod.rs', render('accountsMod.njk', ctx));
                         map.add('src/accounts/postgres/mod.rs', render('accountsPostgresMod.njk', ctx));
-                        map.add('src/accounts/graphql/mod.rs', render('accountsGraphQLMod.njk', ctx));
+                        map.add('src/accounts/graphql/mod.rs', render('accountsGraphqlMod.njk', ctx));
                     }
                     if (instructionsToExport.length > 0) {
                         map.add('src/instructions/mod.rs', render('instructionsMod.njk', ctx));
                         map.add('src/instructions/postgres/mod.rs', render('instructionsPostgresMod.njk', ctx));
-                        map.add('src/instructions/graphql/mod.rs', render('instructionsGraphQLMod.njk', ctx));
+                        map.add('src/instructions/graphql/mod.rs', render('instructionsGraphqlMod.njk', ctx));
                     }
                     
                     if (options.anchorEvents?.length ?? 0 > 0) {
@@ -454,7 +454,7 @@ export function getRenderMapVisitor(options: GetRenderMapOptions = {}) {
 
                     if (definedTypesToExport.length > 0) {
                         map.add('src/types/mod.rs', render('typesMod.njk', ctx));
-                        map.add('src/types/graphql/mod.rs', render('typesGraphQLMod.njk', ctx));
+                        map.add('src/types/graphql/mod.rs', render('typesGraphqlMod.njk', ctx));
                     }
 
                     // GraphQL root (context + query)


### PR DESCRIPTION
Trying to run Carbon CLI i got this error 

```typescript
carbon-cli parse --idl ./idls/myprogram.json -o ./indexer/decoders

 ██████╗ █████╗ ██████╗ ██████╗  ██████╗ ███╗   ██╗
██╔════╝██╔══██╗██╔══██╗██╔══██╗██╔═══██╗████╗  ██║
██║     ███████║██████╔╝██████╔╝██║   ██║██╔██╗ ██║
██║     ██╔══██║██╔══██╗██╔══██╗██║   ██║██║╚██╗██║
╚██████╗██║  ██║██║  ██║██████╔╝╚██████╔╝██║ ╚████║
 ╚═════╝╚═╝  ╚═╝╚═╝  ╚═╝╚═════╝  ╚═════╝ ╚═╝  ╚═══╝
                                                      
Generate decoders and scaffold indexers for your Solana programs.
    
✖ Failed to generate decoder
/home/user/.nvm/versions/node/v23.10.0/lib/node_modules/@sevenlabs-hq/carbon-cli/node_modules/nunjucks/src/environment.js:234
        err = new Error('template not found: ' + name);
              ^

Error: template not found: accountsGraphQLMod.njk
    at createTemplate (/home/user/.nvm/versions/node/v23.10.0/lib/node_modules/@sevenlabs-hq/carbon-cli/node_modules/nunjucks/src/environment.js:234:15)
    at next (/home/user/.nvm/versions/node/v23.10.0/lib/node_modules/@sevenlabs-hq/carbon-cli/node_modules/nunjucks/src/lib.js:260:7)
    at handle (/home/user/.nvm/versions/node/v23.10.0/lib/node_modules/@sevenlabs-hq/carbon-cli/node_modules/nunjucks/src/environment.js:267:11)
    at /home/user/.nvm/versions/node/v23.10.0/lib/node_modules/@sevenlabs-hq/carbon-cli/node_modules/nunjucks/src/environment.js:276:9
    at next (/home/user/.nvm/versions/node/v23.10.0/lib/node_modules/@sevenlabs-hq/carbon-cli/node_modules/nunjucks/src/lib.js:258:7)
    at Object.asyncIter (/home/user/.nvm/versions/node/v23.10.0/lib/node_modules/@sevenlabs-hq/carbon-cli/node_modules/nunjucks/src/lib.js:263:3)
    at Environment.getTemplate (/home/user/.nvm/versions/node/v23.10.0/lib/node_modules/@sevenlabs-hq/carbon-cli/node_modules/nunjucks/src/environment.js:259:9)
    at Environment.render (/home/user/.nvm/versions/node/v23.10.0/lib/node_modules/@sevenlabs-hq/carbon-cli/node_modules/nunjucks/src/environment.js:295:10)
    at render (file:///home/user/.nvm/versions/node/v23.10.0/lib/node_modules/@sevenlabs-hq/carbon-cli/node_modules/@sevenlabs-hq/carbon-codama-renderer/dist/index.mjs:77:14)
    at Object.visitRoot (file:///home/user/.nvm/versions/node/v23.10.0/lib/node_modules/@sevenlabs-hq/carbon-cli/node_modules/@sevenlabs-hq/carbon-codama-renderer/dist/index.mjs:1124:50)

```

List of file names

```
 ls $(npm root -g)/@sevenlabs-hq/carbon-cli/node_modules/@sevenlabs-hq/carbon-codama-renderer/templates/
accountsGraphqlMod.njk                 graphqlContextPage.njk       layout.njk
accountsMod.njk                        graphqlEnumSchemaPage.njk    lib.njk
accountsPage.njk                       graphqlQueryPage.njk         macros.njk
accountsPostgresMod.njk                graphqlRootMod.njk           postgresRowPage.njk
cargo.njk                              graphqlSchemaPage.njk        typesGraphqlMod.njk
eventInstructionGraphqlSchemaPage.njk  graphqlTypeSchemaPage.njk    typesMod.njk
eventInstructionPage.njk               instructionsGraphqlMod.njk   typesPage.njk
eventInstructionRowPage.njk            instructionsMod.njk          typesSqlMod.njk
eventsMod.njk                          instructionsPage.njk
eventsPage.njk                         instructionsPostgresMod.njk
```

Issue was due to the wrong file names being used in the renderer, correcting this fixes this issue