### PR TITLE
refactor: add pumpfun create_v2 instruction

### DIFF
--- a/decoders/pumpfun-decoder/src/instructions/create_v2.rs
+++ b/decoders/pumpfun-decoder/src/instructions/create_v2.rs
@@ -1,0 +1,79 @@
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xd6904cec5f8b31b4")]
+pub struct CreateV2 {
+    pub name: String,
+    pub symbol: String,
+    pub uri: String,
+    pub creator: solana_pubkey::Pubkey,
+    pub is_mayhem_mode: bool,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct CreateV2InstructionAccounts {
+    pub mint: solana_pubkey::Pubkey,
+    pub mint_authority: solana_pubkey::Pubkey,
+    pub bonding_curve: solana_pubkey::Pubkey,
+    pub associated_bonding_curve: solana_pubkey::Pubkey,
+    pub global: solana_pubkey::Pubkey,
+    pub user: solana_pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
+    pub associated_token_program: solana_pubkey::Pubkey,
+    pub mayhem_program_id: solana_pubkey::Pubkey,
+    pub global_params: solana_pubkey::Pubkey,
+    pub sol_vault: solana_pubkey::Pubkey,
+    pub mayhem_state: solana_pubkey::Pubkey,
+    pub mayhem_token_vault: solana_pubkey::Pubkey,
+    pub event_authority: solana_pubkey::Pubkey,
+    pub program: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for CreateV2 {
+    type ArrangedAccounts = CreateV2InstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+
+        let mint = next_account(&mut iter)?;
+        let mint_authority = next_account(&mut iter)?;
+        let bonding_curve = next_account(&mut iter)?;
+        let associated_bonding_curve = next_account(&mut iter)?;
+        let global = next_account(&mut iter)?;
+        let user = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let token_program = next_account(&mut iter)?;
+        let associated_token_program = next_account(&mut iter)?;
+        let mayhem_program_id = next_account(&mut iter)?;
+        let global_params = next_account(&mut iter)?;
+        let sol_vault = next_account(&mut iter)?;
+        let mayhem_state = next_account(&mut iter)?;
+        let mayhem_token_vault = next_account(&mut iter)?;
+        let event_authority = next_account(&mut iter)?;
+        let program = next_account(&mut iter)?;
+
+        Some(CreateV2InstructionAccounts {
+            mint,
+            mint_authority,
+            bonding_curve,
+            associated_bonding_curve,
+            global,
+            user,
+            system_program,
+            token_program,
+            associated_token_program,
+            mayhem_program_id,
+            global_params,
+            sol_vault,
+            mayhem_state,
+            mayhem_token_vault,
+            event_authority,
+            program,
+        })
+    }
+}

--- a/decoders/pumpfun-decoder/src/instructions/mod.rs
+++ b/decoders/pumpfun-decoder/src/instructions/mod.rs
@@ -22,6 +22,7 @@ pub mod complete_event;
 pub mod complete_pump_amm_migration_event;
 pub mod create;
 pub mod create_event;
+pub mod create_v2;
 pub mod extend_account;
 pub mod extend_account_event;
 pub mod init_user_volume_accumulator;
@@ -60,6 +61,7 @@ pub enum PumpfunInstruction {
     CloseUserVolumeAccumulator(close_user_volume_accumulator::CloseUserVolumeAccumulator),
     CollectCreatorFee(collect_creator_fee::CollectCreatorFee),
     Create(create::Create),
+    CreateV2(create_v2::CreateV2),
     ExtendAccount(extend_account::ExtendAccount),
     InitUserVolumeAccumulator(init_user_volume_accumulator::InitUserVolumeAccumulator),
     Initialize(initialize::Initialize),
@@ -130,6 +132,7 @@ impl carbon_core::instruction::InstructionDecoder<'_> for PumpfunDecoder {
             PumpfunInstruction::CloseUserVolumeAccumulator => close_user_volume_accumulator::CloseUserVolumeAccumulator,
             PumpfunInstruction::CollectCreatorFee => collect_creator_fee::CollectCreatorFee,
             PumpfunInstruction::Create => create::Create,
+            PumpfunInstruction::CreateV2 => create_v2::CreateV2,
             PumpfunInstruction::ExtendAccount => extend_account::ExtendAccount,
             PumpfunInstruction::InitUserVolumeAccumulator => init_user_volume_accumulator::InitUserVolumeAccumulator,
             PumpfunInstruction::Initialize => initialize::Initialize,


### PR DESCRIPTION
Added `CreateV2` to pumpfun ix list.

Announcement here:
https://github.com/pump-fun/pump-public-docs/blob/f5aa8e1589db211eff5526005d60b765995c893f/README.md

And used this idl:
https://github.com/pump-fun/pump-public-docs/blob/f5aa8e1589db211eff5526005d60b765995c893f/idl/pump.json