### PR TITLE
fix(workspace): correct latent path typos in workspace.dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ carbon-address-lookup-table-decoder = { path = "decoders/address-lookup-table-de
 carbon-associated-token-account-decoder = { path = "decoders/associated-token-account-decoder", version = "0.12.0" }
 carbon-bonkswap-decoder = { path = "decoders/bonkswap-decoder", version = "0.12.0" }
 carbon-boop-decoder = { path = "decoders/boop-decoder", version = "0.12.0" }
-carbon-bubblegum-decoder = { path = "decoders/bubblegum-decoder", version = "0.12.0" }
+carbon-bubblegum-decoder = { path = "decoders/bubblegum_decoder", version = "0.12.0" }
 carbon-circle-message-transmitter-v2-decoder = { path = "decoders/circle-message-transmitter-v2-decoder", version = "0.12.0" }
 carbon-circle-token-messenger-v2-decoder = { path = "decoders/circle-token-messenger-v2-decoder", version = "0.12.0" }
 
@@ -40,6 +40,7 @@ carbon-dflow-aggregator-v4-decoder = { path = "decoders/dflow-aggregator-v4-deco
 carbon-drift-v2-decoder = { path = "decoders/drift-v2-decoder", version = "0.12.0" }
 carbon-fluxbeam-decoder = { path = "decoders/fluxbeam-decoder", version = "0.12.0" }
 carbon-gavel-decoder = { path = "decoders/gavel-decoder", version = "0.12.0" }
+carbon-heaven-decoder = { path = "decoders/heaven-decoder", version = "0.12.0" }
 
 # datasources
 carbon-helius-atlas-ws-datasource = { path = "datasources/helius-atlas-ws-datasource", version = "0.12.0" }


### PR DESCRIPTION
Hi! While building an example that registers every published Carbon decoder via `{ workspace = true }`, I hit two latent issues in `Cargo.toml`'s `[workspace.dependencies]` block.

## 1. `carbon-bubblegum-decoder` path typo

```diff
- carbon-bubblegum-decoder = { path = "decoders/bubblegum-decoder", version = "0.12.0" }
+ carbon-bubblegum-decoder = { path = "decoders/bubblegum_decoder", version = "0.12.0" }
```

The directory on disk is `decoders/bubblegum_decoder/` (underscore, introduced in commit 7d16a53c when the bubblegum decoder was added). The workspace dep declared `bubblegum-decoder` (hyphen). Cargo errors:

```
failed to read `.../decoders/bubblegum-decoder/Cargo.toml`
Caused by: No such file or directory (os error 2)
```

## 2. `carbon-heaven-decoder` missing from `[workspace.dependencies]`

`decoders/heaven-decoder/` exists and is auto-included by the `members = ["decoders/*"]` glob. But it isn't declared in `workspace.dependencies`, so consumers can't use `{ workspace = true }` for it like every other decoder. Added one line to match the existing pattern.

## Why this is latent

CI doesn't catch either issue because no current workspace member happens to depend on `carbon-bubblegum-decoder` or `carbon-heaven-decoder`. The bug only surfaces when a downstream consumer (an example or external project) declares a dep on either crate via `{ workspace = true }`.

## Testing

After this patch:

```
cargo check -p carbon-bubblegum-decoder   # ✓
cargo check -p carbon-heaven-decoder      # ✓
cargo check -p <example using them>       # ✓ (was: failed to load manifest)
```

Single-line changes, no functional change, just makes the implicit dirs explicitly resolvable from the workspace declarations.