### PR TITLE
fix(prometheus-metrics): sanitize metric names more completely

### DIFF
--- a/metrics/prometheus-metrics/src/lib.rs
+++ b/metrics/prometheus-metrics/src/lib.rs
@@ -186,19 +186,6 @@ pub async fn run_metrics_server(
     .await
 }
 
-#[cfg(test)]
-mod tests {
-    use super::sanitize_name;
-
-    #[test]
-    fn sanitizes_metric_names_for_prometheus() {
-        assert_eq!(
-            sanitize_name("rpc.block-crawler.fetch.failed"),
-            "rpc_block_crawler_fetch_failed"
-        );
-    }
-}
-
 #[cfg(feature = "http-server")]
 pub async fn run_default_metrics_server() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     run_metrics_server_with_config(PrometheusServerConfig::default()).await
@@ -263,4 +250,17 @@ pub async fn run_metrics_server_with_config(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_name;
+
+    #[test]
+    fn sanitizes_metric_names_for_prometheus() {
+        assert_eq!(
+            sanitize_name("rpc.block-crawler.fetch.failed"),
+            "rpc_block_crawler_fetch_failed"
+        );
+    }
 }

--- a/metrics/prometheus-metrics/src/lib.rs
+++ b/metrics/prometheus-metrics/src/lib.rs
@@ -164,7 +164,15 @@ fn format_prometheus_text(snapshot: &MetricsSnapshot) -> String {
 }
 
 fn sanitize_name(name: &str) -> String {
-    name.replace('-', "_")
+    name.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == ':' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
 }
 
 #[cfg(feature = "http-server")]
@@ -176,6 +184,19 @@ pub async fn run_metrics_server(
         ..Default::default()
     })
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_name;
+
+    #[test]
+    fn sanitizes_metric_names_for_prometheus() {
+        assert_eq!(
+            sanitize_name("rpc.block-crawler.fetch.failed"),
+            "rpc_block_crawler_fetch_failed"
+        );
+    }
 }
 
 #[cfg(feature = "http-server")]


### PR DESCRIPTION
Carbon metric names are exporter-neutral, but Prometheus exposition requires metric names to use a restricted character set. This updates the Prometheus exporter to map unsupported characters to underscores instead of only replacing hyphens, making the exporter robust for metric names from any Carbon component.

Validation:
- cargo test -p carbon-prometheus-metrics --all-targets --all-features
- cargo clippy -p carbon-prometheus-metrics --all-targets --all-features -- -D warnings
- cargo fmt -- --check
- cargo sort -c -g
- cargo machete