### PR TITLE
fix(renderer): serialize instruction metadata pubkeys as base58

### DIFF
--- a/packages/renderer/templates/eventInstructionPage.njk
+++ b/packages/renderer/templates/eventInstructionPage.njk
@@ -15,7 +15,13 @@ pub enum CpiEvent {
 
 {{ macros.simpleStructDerives() }}
 pub struct CpiEventInstructionAccounts {
+{% if withBase58 %}
+    #[cfg_attr(feature = "base58", serde(serialize_with = "crate::base58::serialize"))]
+{% endif %}
     pub program: solana_pubkey::Pubkey,
+{% if withBase58 %}
+    #[cfg_attr(feature = "base58", serde(serialize_with = "crate::base58::serialize"))]
+{% endif %}
     pub event_authority: solana_pubkey::Pubkey,
     pub remaining: Vec<solana_instruction::AccountMeta>,
 }

--- a/packages/renderer/templates/instructionsMod.njk
+++ b/packages/renderer/templates/instructionsMod.njk
@@ -31,6 +31,9 @@ pub use self::cpi_event::*;
 pub enum {{ program.name | pascalCase }}Instruction {
 {% for instruction in instructionsToExport | sort(false, false, 'name') %}
     {{ instruction.name | pascalCase }} {
+{% if withBase58 %}
+        #[cfg_attr(feature = "base58", serde(serialize_with = "crate::base58::serialize"))]
+{% endif %}
         program_id: solana_pubkey::Pubkey,
         data: {{ instruction.name | pascalCase }},
         accounts: {{ instruction.name | pascalCase }}InstructionAccounts,
@@ -38,6 +41,9 @@ pub enum {{ program.name | pascalCase }}Instruction {
 {% endfor %}
 {% if hasAnchorEvents %}
     CpiEvent {
+{% if withBase58 %}
+        #[cfg_attr(feature = "base58", serde(serialize_with = "crate::base58::serialize"))]
+{% endif %}
         program_id: solana_pubkey::Pubkey,
         data: CpiEvent,
         accounts: CpiEventInstructionAccounts,

--- a/packages/renderer/tests/native-events.test.mjs
+++ b/packages/renderer/tests/native-events.test.mjs
@@ -76,6 +76,54 @@ test('renders native Codama events with their IDL-defined CPI discriminator', ()
     }
 });
 
+test('serializes instruction metadata pubkeys as base58 when enabled', () => {
+    const outputDirectory = mkdtempSync(join(tmpdir(), 'carbon-base58-program-id-'));
+
+    try {
+        const event = nativeEventNode({
+            name: 'paymentCreated',
+            data: structTypeNode([]),
+            discriminators: [
+                constantDiscriminatorNode(constantValueNodeFromBytes('base16', '01020304'), 0),
+                constantDiscriminatorNode(constantValueNodeFromBytes('base16', '09'), 4),
+            ],
+        });
+        const root = rootNode(
+            programWithEvents({
+                name: 'payments',
+                publicKey: '11111111111111111111111111111111',
+                events: [event],
+                instructions: [instructionNode({ name: 'createPayment' })],
+            }),
+        );
+
+        visit(
+            root,
+            renderVisitor(outputDirectory, {
+                standalone: true,
+                withBase58: true,
+                withGraphql: false,
+                withPostgres: false,
+                withSerde: true,
+            }),
+        );
+
+        const instructionsMod = readFileSync(join(outputDirectory, 'src/instructions/mod.rs'), 'utf8');
+        const programIdSerializationAttributes = instructionsMod.match(
+            /serde\(serialize_with = "crate::base58::serialize"\)/g,
+        );
+        assert.equal(programIdSerializationAttributes?.length, 2);
+
+        const cpiEvent = readFileSync(join(outputDirectory, 'src/instructions/cpi_event.rs'), 'utf8');
+        const cpiAccountSerializationAttributes = cpiEvent.match(
+            /serde\(serialize_with = "crate::base58::serialize"\)/g,
+        );
+        assert.equal(cpiAccountSerializationAttributes?.length, 2);
+    } finally {
+        rmSync(outputDirectory, { force: true, recursive: true });
+    }
+});
+
 test('keeps the anchorEvents renderer option backward compatible', () => {
     const outputDirectory = mkdtempSync(join(tmpdir(), 'carbon-anchor-events-'));
 


### PR DESCRIPTION
## Summary

- apply the existing base58 serializer to program_id fields in generated instruction wrapper enums
- serialize program and event_authority in generated CPI-event instruction accounts
- cover regular instructions and CPI-event instruction variants with a renderer regression test

## Why

With base58 generation enabled, Pubkey fields in instruction data and normal accounts serialize as strings, while wrapper and CPI-event metadata pubkeys still serialize as byte arrays. This makes the generated JSON inconsistent and forces consumers to patch generated code.

The new attributes are emitted only when withBase58 is enabled, so default generated output is unchanged.

## Validation

- renderer package tests
- Prettier format check
- TypeScript build and type checks
- generated a decoder from the subscriptions Codama IDL with base58 enabled
- cargo check --features base58 against Carbon 1.0.0