### PR TITLE
fix(renderer): support hidden-prefix Codama event nodes

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -59,6 +59,10 @@ program
     .option('-c, --as-crate', 'Generate as a Cargo crate layout', false)
     .option('-s, --standard <anchor|codama>', 'Specify the IDL standard to parse', 'anchor')
     .option('--event-hints <csv>', 'Comma-separated names of defined types to parse as CPI Events (Codama only)')
+    .option(
+        '--event-cpi-discriminator <hex>',
+        'Event-CPI envelope for hidden-prefix Codama events as hex bytes (default: the Anchor event tag e445a52e51cb9a1d)',
+    )
     .option('-u, --url <rpcUrl>', 'RPC URL for fetching IDL when using a program address')
     .option('--program-id <address>', 'Program ID (used if IDL lacks address field)')
     .option('--postgres-mode <generic|typed>', 'Postgres table storage mode', 'typed')
@@ -133,6 +137,7 @@ program
                 standard: opts.standard,
                 url: opts.url,
                 eventHints: opts.eventHints,
+                eventCpiDiscriminator: opts.eventCpiDiscriminator,
                 deleteFolderBeforeRendering: Boolean(opts.clean),
                 programId: opts.programId,
                 packageName,
@@ -182,6 +187,10 @@ program
     .option('--idl-standard <anchor|codama>', 'IDL standard')
     .option('--idl-url <rpcUrl>', 'RPC URL for fetching IDL (when using program address)')
     .option('--event-hints <csv>', 'Event hints for Codama IDL')
+    .option(
+        '--event-cpi-discriminator <hex>',
+        'Event-CPI envelope for hidden-prefix Codama events as hex bytes (default: the Anchor event tag e445a52e51cb9a1d)',
+    )
     .option('--program-id <address>', 'Program ID (used if IDL lacks address field)')
     .option('-s, --data-source <name>', 'Name of data source')
     .option('-m, --metrics <log|prometheus>', 'Metrics to use', 'log')
@@ -278,6 +287,7 @@ program
                 standard: opts.idlStandard,
                 url: opts.idlUrl,
                 eventHints: opts.eventHints,
+                eventCpiDiscriminator: opts.eventCpiDiscriminator,
                 deleteFolderBeforeRendering: true,
                 programId: opts.programId,
                 packageName: decoder,

--- a/packages/cli/src/lib/decoder.ts
+++ b/packages/cli/src/lib/decoder.ts
@@ -68,6 +68,7 @@ export type DecoderGenerationOptions = {
     standard?: string;
     url?: string;
     eventHints?: string;
+    eventCpiDiscriminator?: string;
     deleteFolderBeforeRendering?: boolean;
     programId?: string;
     packageName?: string;
@@ -96,6 +97,24 @@ function getValidIdlAddress(idlJson: any): string | undefined {
         return addr as string;
     }
     return undefined;
+}
+
+/**
+ * Parses the --event-cpi-discriminator hex string into bytes
+ */
+export function parseEventCpiDiscriminator(hex?: string): number[] | undefined {
+    if (hex === undefined) {
+        return undefined;
+    }
+    const cleaned = hex.trim().replace(/^0x/i, '');
+    if (!/^[0-9a-fA-F]+$/.test(cleaned) || cleaned.length % 2 !== 0) {
+        exitWithError('Invalid --event-cpi-discriminator: expected an even-length hex string (e.g. e445a52e51cb9a1d)');
+    }
+    const bytes: number[] = [];
+    for (let index = 0; index < cleaned.length; index += 2) {
+        bytes.push(parseInt(cleaned.slice(index, index + 2), 16));
+    }
+    return bytes;
 }
 
 /**
@@ -154,6 +173,7 @@ export function validateDecoderOptions(
     url?: string,
     eventHints?: string,
     programId?: string,
+    eventCpiDiscriminator?: string,
 ): void {
     if (idlSource.type === 'program') {
         if (!url) {
@@ -166,6 +186,10 @@ export function validateDecoderOptions(
 
     if (standard === 'anchor' && eventHints) {
         exitWithError('Event hints can only be used with Codama standard');
+    }
+
+    if (standard === 'anchor' && eventCpiDiscriminator) {
+        exitWithError('--event-cpi-discriminator can only be used with Codama standard');
     }
 
     if (programId) {
@@ -242,11 +266,12 @@ export async function generateDecoder(options: DecoderGenerationOptions): Promis
 
     const idlSource = parseIdlSource(idl);
     const standard = validateIdlStandard(standardOpt || 'anchor', idlSource);
-    validateDecoderOptions(standard, idlSource, url, options.eventHints, programId);
+    validateDecoderOptions(standard, idlSource, url, options.eventHints, programId, options.eventCpiDiscriminator);
 
     // Common render options shared across all branches
     const renderOpts = {
         deleteFolderBeforeRendering,
+        eventCpiDiscriminator: parseEventCpiDiscriminator(options.eventCpiDiscriminator),
         packageName,
         postgresMode,
         withPostgres,

--- a/packages/renderer/README.md
+++ b/packages/renderer/README.md
@@ -17,9 +17,12 @@ This package is used internally by [`@sevenlabs-hq/carbon-cli`](https://www.npmj
 
 Codama `eventNode` values are rendered automatically. The renderer derives the
 event-CPI discriminator and each event discriminator from the IDL, generates the
-typed event data, and adds the `CpiEvent` instruction variant. The existing
-`anchorEvents` renderer option remains available for Anchor IDLs that represent
-events as defined types.
+typed event data, and adds the `CpiEvent` instruction variant. Events encoded as
+a `hiddenPrefixTypeNode` carry no event-CPI envelope in the IDL; they default to
+the Anchor event-CPI discriminator `[228, 69, 165, 46, 81, 203, 154, 29]`, and
+the `eventCpiDiscriminator` renderer option overrides that default for programs
+with a custom envelope. The existing `anchorEvents` renderer option remains
+available for Anchor IDLs that represent events as defined types.
 
 ## Links
 

--- a/packages/renderer/src/eventNodes.ts
+++ b/packages/renderer/src/eventNodes.ts
@@ -1,4 +1,5 @@
-import { definedTypeNode, RootNode } from '@codama/nodes';
+import { definedTypeNode, isNode, RootNode } from '@codama/nodes';
+
 import { getDiscriminatorBytes } from './utils';
 
 export type RenderEvent = {
@@ -13,9 +14,16 @@ export type NormalizedCodamaEvents = {
     eventDataOffset: number;
 };
 
+export type NormalizeCodamaEventsOptions = {
+    eventCpiDiscriminator?: number[];
+};
+
 export const LEGACY_ANCHOR_EVENT_CPI_DISCRIMINATOR = [228, 69, 165, 46, 81, 203, 154, 29];
 
-export function normalizeCodamaEvents(root: RootNode): NormalizedCodamaEvents | null {
+export function normalizeCodamaEvents(
+    root: RootNode,
+    options: NormalizeCodamaEventsOptions = {},
+): NormalizedCodamaEvents | null {
     // Codama 1.3 preserves eventNode values from JSON even though its public
     // ProgramNode type does not expose them yet. Keep the existing dependency
     // versions and narrow the structural extension locally.
@@ -24,86 +32,67 @@ export function normalizeCodamaEvents(root: RootNode): NormalizedCodamaEvents | 
         return null;
     }
 
-    const eventDiscriminators = nativeEvents.map(event => {
-        const discriminators = event.discriminators ?? [];
-        const constantDiscriminators = discriminators.filter(
-            discriminator => discriminator.kind === 'constantDiscriminatorNode',
-        );
-        if (constantDiscriminators.length !== discriminators.length) {
+    const shapes: EventShape[] = [];
+    for (const event of nativeEvents) {
+        const shape = classicEventShape(event) ?? hiddenPrefixEventShape(event);
+        if (shape === null) {
+            warn(`event "${event.name}" does not describe a supported event-CPI payload; skipping event decoding`);
             return null;
         }
-
-        const sorted = [...constantDiscriminators].sort((left, right) => left.offset - right.offset);
-        if (sorted.length < 2 || sorted[0].offset !== 0) {
-            return null;
-        }
-
-        const eventCpiDiscriminator = tryGetDiscriminatorBytes(sorted[0].constant);
-        if (eventCpiDiscriminator === null) {
-            return null;
-        }
-        if (eventCpiDiscriminator.length === 0) {
-            return null;
-        }
-        const eventDiscriminator: number[] = [];
-        let expectedOffset = eventCpiDiscriminator.length;
-        for (const discriminator of sorted.slice(1)) {
-            if (discriminator.offset !== expectedOffset) {
-                return null;
-            }
-            const bytes = tryGetDiscriminatorBytes(discriminator.constant);
-            if (bytes === null) {
-                return null;
-            }
-            eventDiscriminator.push(...bytes);
-            expectedOffset += bytes.length;
-        }
-        if (eventDiscriminator.length === 0) {
-            return null;
-        }
-
-        return {
-            cpiDiscriminator: eventCpiDiscriminator,
-            discriminator: eventDiscriminator,
-        };
-    });
-    if (eventDiscriminators.some(discriminator => discriminator === null)) {
-        return null;
+        shapes.push(shape);
     }
-    const validEventDiscriminators = eventDiscriminators.filter(discriminator => discriminator !== null);
 
-    const cpiDiscriminator = validEventDiscriminators[0].cpiDiscriminator;
-    for (let index = 1; index < validEventDiscriminators.length; index += 1) {
-        if (!equalBytes(cpiDiscriminator, validEventDiscriminators[index].cpiDiscriminator)) {
+    const explicitCpiDiscriminators = shapes.flatMap(shape =>
+        shape.cpiDiscriminator === null ? [] : [shape.cpiDiscriminator],
+    );
+    for (let index = 1; index < explicitCpiDiscriminators.length; index += 1) {
+        if (!equalBytes(explicitCpiDiscriminators[0], explicitCpiDiscriminators[index])) {
+            warn('events declare conflicting event-CPI discriminators; skipping event decoding');
             return null;
         }
     }
+    // The hidden-prefix shape carries no event-CPI envelope. An emit wrapper
+    // instruction's dispatch discriminator can be a strict prefix of the bytes
+    // the program writes on the wire (payment-channels dispatches on byte 228
+    // but emits the full 8-byte Anchor tag), so instruction discriminators
+    // must never define framing.
+    const cpiDiscriminator =
+        explicitCpiDiscriminators[0] ?? options.eventCpiDiscriminator ?? LEGACY_ANCHOR_EVENT_CPI_DISCRIMINATOR;
 
     const eventNames = new Set<string>();
     for (const event of nativeEvents) {
         if (eventNames.has(event.name)) {
+            warn(`duplicate event name "${event.name}"; skipping event decoding`);
             return null;
         }
         eventNames.add(event.name);
     }
 
-    const definedTypeNames = new Set(root.program.definedTypes.map(type => type.name));
-    const eventTypes = nativeEvents.flatMap(event => {
-        if (definedTypeNames.has(event.name)) {
-            return [];
+    const definedTypesByName = new Map(root.program.definedTypes.map(type => [type.name as string, type]));
+    const eventTypes: ReturnType<typeof definedTypeNode>[] = [];
+    for (const event of nativeEvents) {
+        const payload = unwrapHiddenPrefix(event.data);
+        const existing = definedTypesByName.get(event.name);
+        if (existing !== undefined) {
+            if (!sameShape(existing.type, payload)) {
+                warn(
+                    `event "${event.name}" collides with a defined type of a different shape; skipping event decoding`,
+                );
+                return null;
+            }
+            continue;
         }
-        definedTypeNames.add(event.name);
-        return [
+        eventTypes.push(
             definedTypeNode({
                 name: event.name,
                 docs: event.docs,
-                type: event.data,
+                type: payload,
             }),
-        ];
-    });
+        );
+    }
     const events = nativeEvents.map((event, index) => ({
         name: event.name,
-        discriminator: validEventDiscriminators[index].discriminator,
+        discriminator: shapes[index].discriminator,
     }));
 
     return {
@@ -121,6 +110,11 @@ export function normalizeCodamaEvents(root: RootNode): NormalizedCodamaEvents | 
     };
 }
 
+type EventShape = {
+    cpiDiscriminator: number[] | null;
+    discriminator: number[];
+};
+
 type CodamaEventNode = {
     name: RootNode['program']['name'];
     docs?: Parameters<typeof definedTypeNode>[0]['docs'];
@@ -131,6 +125,128 @@ type CodamaEventNode = {
         constant: Parameters<typeof getDiscriminatorBytes>[0];
     }>;
 };
+
+function classicEventShape(event: CodamaEventNode): EventShape | null {
+    const discriminators = event.discriminators ?? [];
+    const constantDiscriminators = discriminators.filter(
+        discriminator => discriminator.kind === 'constantDiscriminatorNode',
+    );
+    if (constantDiscriminators.length !== discriminators.length) {
+        return null;
+    }
+
+    const sorted = [...constantDiscriminators].sort((left, right) => left.offset - right.offset);
+    if (sorted.length < 2 || sorted[0].offset !== 0) {
+        return null;
+    }
+
+    const eventCpiDiscriminator = tryGetDiscriminatorBytes(sorted[0].constant);
+    if (eventCpiDiscriminator === null) {
+        return null;
+    }
+    if (eventCpiDiscriminator.length === 0) {
+        return null;
+    }
+    const eventDiscriminator: number[] = [];
+    let expectedOffset = eventCpiDiscriminator.length;
+    for (const discriminator of sorted.slice(1)) {
+        if (discriminator.offset !== expectedOffset) {
+            return null;
+        }
+        const bytes = tryGetDiscriminatorBytes(discriminator.constant);
+        if (bytes === null) {
+            return null;
+        }
+        eventDiscriminator.push(...bytes);
+        expectedOffset += bytes.length;
+    }
+    if (eventDiscriminator.length === 0) {
+        return null;
+    }
+
+    return {
+        cpiDiscriminator: eventCpiDiscriminator,
+        discriminator: eventDiscriminator,
+    };
+}
+
+// Codama also encodes an event as a single discriminator at offset zero whose
+// bytes repeat as a hiddenPrefixTypeNode constant on the data type. The
+// event-CPI envelope is not part of the event node in that shape; it comes
+// from the eventCpiDiscriminator renderer option or the legacy Anchor
+// constant.
+function hiddenPrefixEventShape(event: CodamaEventNode): EventShape | null {
+    const discriminators = event.discriminators ?? [];
+    if (discriminators.length !== 1) {
+        return null;
+    }
+    const [discriminator] = discriminators;
+    if (discriminator.kind !== 'constantDiscriminatorNode' || discriminator.offset !== 0) {
+        return null;
+    }
+    const bytes = tryGetDiscriminatorBytes(discriminator.constant);
+    if (bytes === null || bytes.length === 0) {
+        return null;
+    }
+
+    const data = event.data;
+    if (!isNode(data, 'hiddenPrefixTypeNode') || data.prefix.length !== 1) {
+        return null;
+    }
+    const prefixBytes = tryGetDiscriminatorBytes(data.prefix[0]);
+    if (prefixBytes === null || !equalBytes(bytes, prefixBytes)) {
+        return null;
+    }
+    // The event page renders the payload as a struct body; other type kinds
+    // would produce invalid Rust.
+    if (!isNode(data.type, 'structTypeNode')) {
+        return null;
+    }
+
+    return {
+        cpiDiscriminator: null,
+        discriminator: bytes,
+    };
+}
+
+function unwrapHiddenPrefix(data: CodamaEventNode['data']): CodamaEventNode['data'] {
+    return isNode(data, 'hiddenPrefixTypeNode') ? data.type : data;
+}
+
+// Key order in IDL JSON is not significant and docs never affect the wire
+// layout, so neither may influence the comparison.
+function sameShape(left: unknown, right: unknown): boolean {
+    if (left === right) {
+        return true;
+    }
+    if (Array.isArray(left) || Array.isArray(right)) {
+        return (
+            Array.isArray(left) &&
+            Array.isArray(right) &&
+            left.length === right.length &&
+            left.every((item, index) => sameShape(item, right[index]))
+        );
+    }
+    if (typeof left !== 'object' || typeof right !== 'object' || left === null || right === null) {
+        return false;
+    }
+    const leftRecord = left as Record<string, unknown>;
+    const rightRecord = right as Record<string, unknown>;
+    const shapeKeys = (record: Record<string, unknown>) =>
+        Object.keys(record)
+            .filter(key => key !== 'docs' && record[key] !== undefined)
+            .sort();
+    const leftKeys = shapeKeys(leftRecord);
+    const rightKeys = shapeKeys(rightRecord);
+    return (
+        leftKeys.length === rightKeys.length &&
+        leftKeys.every((key, index) => key === rightKeys[index] && sameShape(leftRecord[key], rightRecord[key]))
+    );
+}
+
+function warn(message: string): void {
+    console.warn(`[carbon-codama-renderer] ${message}`);
+}
 
 function equalBytes(left: number[], right: number[]): boolean {
     return left.length === right.length && left.every((byte, index) => byte === right[index]);

--- a/packages/renderer/src/getRenderMapVisitor.ts
+++ b/packages/renderer/src/getRenderMapVisitor.ts
@@ -42,6 +42,7 @@ export type GetRenderMapOptions = {
         name: string;
         discriminator: number[];
     }[];
+    eventCpiDiscriminator?: number[];
     postgresMode?: 'generic' | 'typed';
     withPostgres?: boolean;
     withGraphql?: boolean;
@@ -642,7 +643,9 @@ export function getRenderMapVisitor(options: GetRenderMapOptions = {}) {
 
                 visitRoot(node, { self }) {
                     let renderRoot = node;
-                    const normalizedEvents = hasExplicitAnchorEvents ? null : normalizeCodamaEvents(node);
+                    const normalizedEvents = hasExplicitAnchorEvents
+                        ? null
+                        : normalizeCodamaEvents(node, { eventCpiDiscriminator: options.eventCpiDiscriminator });
                     if (normalizedEvents !== null) {
                         renderRoot = normalizedEvents.root;
                         renderEvents = normalizedEvents.events;

--- a/packages/renderer/src/utils/discriminatorHelpers.ts
+++ b/packages/renderer/src/utils/discriminatorHelpers.ts
@@ -1,51 +1,59 @@
-import { ConstantValueNode, isNode } from '@codama/nodes';
+import { BytesEncoding, ConstantValueNode, isNode } from '@codama/nodes';
+import { getBase16Encoder, getBase58Encoder, getBase64Encoder, getUtf8Encoder } from '@solana/codecs-strings';
 
 export function getDiscriminatorBytes(constant: ConstantValueNode): number[] {
     if (isNode(constant.value, 'bytesValueNode')) {
-        return hexToBytes(constant.value.data);
+        return encodedStringToBytes(constant.value.data, constant.value.encoding);
     } else if (isNode(constant.value, 'numberValueNode')) {
         const numberType = constant.type;
         if (isNode(numberType, 'numberTypeNode')) {
-            return numberToBytes(constant.value.number, numberType.format);
+            return numberToBytes(constant.value.number, numberType.format, numberType.endian);
         }
     } else if (isNode(constant.value, 'stringValueNode') && isNode(constant.type, 'stringTypeNode')) {
-        return stringToBytes(constant.value.string);
+        return encodedStringToBytes(constant.value.string, constant.type.encoding);
     }
 
     throw new Error(`Unsupported discriminator type: ${constant.value.kind}`);
 }
 
-function hexToBytes(hex: string): number[] {
-    const cleanHex = hex.replace(/^0x/, '');
-    const bytes: number[] = [];
-    for (let i = 0; i < cleanHex.length; i += 2) {
-        bytes.push(parseInt(cleanHex.substr(i, 2), 16));
+function encodedStringToBytes(value: string, encoding: BytesEncoding): number[] {
+    switch (encoding) {
+        case 'base16':
+            return Array.from(getBase16Encoder().encode(value.replace(/^0x/, '')));
+        case 'base58':
+            return Array.from(getBase58Encoder().encode(value));
+        case 'base64':
+            return Array.from(getBase64Encoder().encode(value));
+        case 'utf8':
+            return Array.from(getUtf8Encoder().encode(value));
     }
-    return bytes;
 }
 
-function numberToBytes(num: number, format: string): number[] {
+function numberToBytes(num: number, format: string, endian: 'be' | 'le'): number[] {
+    let bytes: number[];
+
     switch (format) {
         case 'u8':
-            return [num & 0xff];
+            bytes = [num & 0xff];
+            break;
         case 'u16':
-            return [num & 0xff, (num >> 8) & 0xff];
+            bytes = [num & 0xff, (num >> 8) & 0xff];
+            break;
         case 'u32':
-            return [num & 0xff, (num >> 8) & 0xff, (num >> 16) & 0xff, (num >> 24) & 0xff];
+            bytes = [num & 0xff, (num >> 8) & 0xff, (num >> 16) & 0xff, (num >> 24) & 0xff];
+            break;
         case 'u64': {
-            const bytes: number[] = [];
+            bytes = [];
             let n = num;
             for (let i = 0; i < 8; i++) {
                 bytes.push(n & 0xff);
                 n = Math.floor(n / 256);
             }
-            return bytes;
+            break;
         }
         default:
             throw new Error(`Unsupported number format: ${format}`);
     }
-}
 
-function stringToBytes(str: string): number[] {
-    return Array.from(new TextEncoder().encode(str));
+    return endian === 'be' ? bytes.reverse() : bytes;
 }

--- a/packages/renderer/templates/instructionsMod.njk
+++ b/packages/renderer/templates/instructionsMod.njk
@@ -65,12 +65,12 @@ impl carbon_core::instruction::InstructionDecoder<'_> for {{ program.name | pasc
         carbon_core::try_decode_instructions!(
             instruction,
             PROGRAM_ID,
-{% for instruction in instructionsToExport | sort(false, false, 'name') %}
-            {{ program.name | pascalCase }}Instruction::{{ instruction.name | pascalCase }} => {{ instruction.name | pascalCase }},
-{% endfor %}
 {% if hasAnchorEvents %}
             {{ program.name | pascalCase }}Instruction::CpiEvent => CpiEvent,
 {% endif %}
+{% for instruction in instructionsToExport | sort(false, false, 'name') %}
+            {{ program.name | pascalCase }}Instruction::{{ instruction.name | pascalCase }} => {{ instruction.name | pascalCase }},
+{% endfor %}
         )
     }
 }

--- a/packages/renderer/tests/native-events.test.mjs
+++ b/packages/renderer/tests/native-events.test.mjs
@@ -8,12 +8,18 @@ import {
     constantDiscriminatorNode,
     constantValueNodeFromBytes,
     definedTypeNode,
+    fieldDiscriminatorNode,
+    hiddenPrefixTypeNode,
+    instructionArgumentNode,
     instructionNode,
     numberTypeNode,
+    numberValueNode,
     programNode,
+    publicKeyTypeNode,
     rootNode,
     structFieldTypeNode,
     structTypeNode,
+    tupleTypeNode,
 } from '@codama/nodes';
 import { visit } from '@codama/visitors-core';
 
@@ -119,6 +125,448 @@ test('serializes instruction metadata pubkeys as base58 when enabled', () => {
             /serde\(serialize_with = "crate::base58::serialize"\)/g,
         );
         assert.equal(cpiAccountSerializationAttributes?.length, 2);
+    } finally {
+        rmSync(outputDirectory, { force: true, recursive: true });
+    }
+});
+
+test('frames hidden-prefix events with the full Anchor event-CPI envelope', () => {
+    const outputDirectory = mkdtempSync(join(tmpdir(), 'carbon-hidden-prefix-events-'));
+
+    try {
+        const anchorEventCpiTag = [228, 69, 165, 46, 81, 203, 154, 29];
+        const openedDiscriminator = [166, 172, 97, 9, 77, 76, 189, 109];
+        const openedWireBytes = [
+            ...anchorEventCpiTag,
+            ...openedDiscriminator,
+            ...new Array(32).fill(7),
+            ...[42, 0, 0, 0, 0, 0, 0, 0],
+        ];
+
+        const eventTag = constantValueNodeFromBytes('base16', 'a6ac61094d4cbd6d');
+        const event = nativeEventNode({
+            name: 'opened',
+            data: hiddenPrefixTypeNode(
+                structTypeNode([
+                    structFieldTypeNode({
+                        name: 'channel',
+                        type: publicKeyTypeNode(),
+                    }),
+                    structFieldTypeNode({
+                        name: 'openSlot',
+                        type: numberTypeNode('u64'),
+                    }),
+                ]),
+                [eventTag],
+            ),
+            discriminators: [constantDiscriminatorNode(eventTag, 0)],
+        });
+        const emitInstruction = instructionNode({
+            accounts: [
+                {
+                    isSigner: true,
+                    isWritable: false,
+                    kind: 'instructionAccountNode',
+                    name: 'eventAuthority',
+                },
+            ],
+            arguments: [
+                instructionArgumentNode({
+                    defaultValue: numberValueNode(228),
+                    defaultValueStrategy: 'omitted',
+                    name: 'discriminator',
+                    type: numberTypeNode('u8'),
+                }),
+            ],
+            discriminators: [fieldDiscriminatorNode('discriminator', 0)],
+            name: 'emitEvent',
+        });
+        const regularInstruction = instructionNode({
+            arguments: [
+                instructionArgumentNode({
+                    defaultValue: numberValueNode(1),
+                    defaultValueStrategy: 'omitted',
+                    name: 'discriminator',
+                    type: numberTypeNode('u8'),
+                }),
+            ],
+            discriminators: [fieldDiscriminatorNode('discriminator', 0)],
+            name: 'createPayment',
+        });
+        const root = rootNode(
+            programWithEvents({
+                name: 'payments',
+                publicKey: '11111111111111111111111111111111',
+                events: [event],
+                instructions: [regularInstruction, emitInstruction],
+            }),
+        );
+
+        visit(
+            root,
+            renderVisitor(outputDirectory, {
+                standalone: true,
+                withGraphql: false,
+                withPostgres: false,
+                withSerde: true,
+            }),
+        );
+
+        const envelope = openedWireBytes.slice(0, 8);
+        const eventDiscriminator = openedWireBytes.slice(8, 16);
+
+        const cpiEvent = readFileSync(join(outputDirectory, 'src/instructions/cpi_event.rs'), 'utf8');
+        assert.match(cpiEvent, new RegExp(`if data\\.len\\(\\) < ${envelope.length}`));
+        assert.match(cpiEvent, new RegExp(`if discriminator != \\[${envelope.join(', ')}\\]`));
+        assert.match(cpiEvent, new RegExp(`let event_data = &data\\[${envelope.length}\\.\\.\\]`));
+
+        const generatedEvent = readFileSync(join(outputDirectory, 'src/events/opened.rs'), 'utf8');
+        assert.match(generatedEvent, /pub struct OpenedEvent/);
+        assert.match(generatedEvent, new RegExp(`if discriminator != \\[${eventDiscriminator.join(', ')}\\]`));
+        assert.match(generatedEvent, /pub channel: Pubkey/);
+        assert.match(generatedEvent, /pub open_slot: u64/);
+
+        assert.equal(existsSync(join(outputDirectory, 'src/instructions/emit_event.rs')), true);
+        assert.equal(existsSync(join(outputDirectory, 'src/instructions/create_payment.rs')), true);
+
+        const instructionsMod = readFileSync(join(outputDirectory, 'src/instructions/mod.rs'), 'utf8');
+        const cpiEventArm = instructionsMod.indexOf('PaymentsInstruction::CpiEvent => CpiEvent');
+        const emitEventArm = instructionsMod.indexOf('PaymentsInstruction::EmitEvent => EmitEvent');
+        const createPaymentArm = instructionsMod.indexOf('PaymentsInstruction::CreatePayment => CreatePayment');
+        assert.notEqual(cpiEventArm, -1);
+        assert.notEqual(emitEventArm, -1);
+        assert.notEqual(createPaymentArm, -1);
+        assert.ok(cpiEventArm < emitEventArm);
+        assert.ok(cpiEventArm < createPaymentArm);
+    } finally {
+        rmSync(outputDirectory, { force: true, recursive: true });
+    }
+});
+
+test('ignores hidden-prefix events whose payload is not a struct', () => {
+    const outputDirectory = mkdtempSync(join(tmpdir(), 'carbon-hidden-prefix-tuple-'));
+
+    try {
+        const eventTag = constantValueNodeFromBytes('base16', 'a6ac61094d4cbd6d');
+        const root = rootNode(
+            programWithEvents({
+                name: 'payments',
+                publicKey: '11111111111111111111111111111111',
+                events: [
+                    nativeEventNode({
+                        name: 'tupleEvent',
+                        data: hiddenPrefixTypeNode(tupleTypeNode([numberTypeNode('u32'), numberTypeNode('u64')]), [
+                            eventTag,
+                        ]),
+                        discriminators: [constantDiscriminatorNode(eventTag, 0)],
+                    }),
+                ],
+                instructions: [instructionNode({ name: 'createPayment' })],
+            }),
+        );
+
+        visit(
+            root,
+            renderVisitor(outputDirectory, {
+                standalone: true,
+                withGraphql: false,
+                withPostgres: false,
+            }),
+        );
+
+        assert.equal(existsSync(join(outputDirectory, 'src/instructions/cpi_event.rs')), false);
+        assert.equal(existsSync(join(outputDirectory, 'src/instructions/create_payment.rs')), true);
+    } finally {
+        rmSync(outputDirectory, { force: true, recursive: true });
+    }
+});
+
+test('lets the eventCpiDiscriminator option override the hidden-prefix envelope', () => {
+    const outputDirectory = mkdtempSync(join(tmpdir(), 'carbon-envelope-option-'));
+
+    try {
+        const eventTag = constantValueNodeFromBytes('base16', 'd116b9d754a75450');
+        const root = rootNode(
+            programWithEvents({
+                name: 'payments',
+                publicKey: '11111111111111111111111111111111',
+                events: [
+                    nativeEventNode({
+                        name: 'payoutRedirected',
+                        data: hiddenPrefixTypeNode(structTypeNode([]), [eventTag]),
+                        discriminators: [constantDiscriminatorNode(eventTag, 0)],
+                    }),
+                ],
+                instructions: [instructionNode({ name: 'createPayment' })],
+            }),
+        );
+
+        visit(
+            root,
+            renderVisitor(outputDirectory, {
+                eventCpiDiscriminator: [13, 37],
+                standalone: true,
+                withGraphql: false,
+                withPostgres: false,
+            }),
+        );
+
+        const cpiEvent = readFileSync(join(outputDirectory, 'src/instructions/cpi_event.rs'), 'utf8');
+        assert.match(cpiEvent, /if data\.len\(\) < 2/);
+        assert.match(cpiEvent, /if discriminator != \[13, 37\]/);
+        assert.match(cpiEvent, /let event_data = &data\[2\.\.\]/);
+
+        const generatedEvent = readFileSync(join(outputDirectory, 'src/events/payout_redirected.rs'), 'utf8');
+        assert.match(generatedEvent, /if discriminator != \[209, 22, 185, 215, 84, 167, 84, 80\]/);
+    } finally {
+        rmSync(outputDirectory, { force: true, recursive: true });
+    }
+});
+
+test('skips event decoding when an event collides with a defined type of a different shape', () => {
+    const outputDirectory = mkdtempSync(join(tmpdir(), 'carbon-defined-type-clash-'));
+
+    try {
+        const eventTag = constantValueNodeFromBytes('base16', 'a6ac61094d4cbd6d');
+        const root = rootNode(
+            programWithEvents({
+                name: 'payments',
+                publicKey: '11111111111111111111111111111111',
+                definedTypes: [
+                    definedTypeNode({
+                        name: 'opened',
+                        type: structTypeNode([
+                            structFieldTypeNode({
+                                name: 'amount',
+                                type: numberTypeNode('u64'),
+                            }),
+                        ]),
+                    }),
+                ],
+                events: [
+                    nativeEventNode({
+                        name: 'opened',
+                        data: hiddenPrefixTypeNode(
+                            structTypeNode([
+                                structFieldTypeNode({
+                                    name: 'slot',
+                                    type: numberTypeNode('u64'),
+                                }),
+                            ]),
+                            [eventTag],
+                        ),
+                        discriminators: [constantDiscriminatorNode(eventTag, 0)],
+                    }),
+                ],
+                instructions: [instructionNode({ name: 'createPayment' })],
+            }),
+        );
+
+        const warnings = [];
+        const originalWarn = console.warn;
+        console.warn = message => warnings.push(String(message));
+        try {
+            visit(
+                root,
+                renderVisitor(outputDirectory, {
+                    standalone: true,
+                    withGraphql: false,
+                    withPostgres: false,
+                }),
+            );
+        } finally {
+            console.warn = originalWarn;
+        }
+
+        assert.equal(existsSync(join(outputDirectory, 'src/instructions/cpi_event.rs')), false);
+        assert.equal(existsSync(join(outputDirectory, 'src/instructions/create_payment.rs')), true);
+        assert.ok(warnings.some(warning => warning.includes('"opened"')));
+    } finally {
+        rmSync(outputDirectory, { force: true, recursive: true });
+    }
+});
+
+test('reuses an existing defined type for a hidden-prefix event', () => {
+    const outputDirectory = mkdtempSync(join(tmpdir(), 'carbon-hidden-prefix-defined-type-'));
+
+    try {
+        const eventTag = constantValueNodeFromBytes('base16', 'a6ac61094d4cbd6d');
+        const fields = [
+            structFieldTypeNode({
+                name: 'amount',
+                type: numberTypeNode('u64'),
+            }),
+        ];
+        const root = rootNode(
+            programWithEvents({
+                name: 'payments',
+                publicKey: '11111111111111111111111111111111',
+                definedTypes: [
+                    definedTypeNode({
+                        name: 'opened',
+                        type: structTypeNode(fields),
+                    }),
+                ],
+                events: [
+                    nativeEventNode({
+                        name: 'opened',
+                        data: hiddenPrefixTypeNode(structTypeNode(fields), [eventTag]),
+                        discriminators: [constantDiscriminatorNode(eventTag, 0)],
+                    }),
+                ],
+                instructions: [instructionNode({ name: 'createPayment' })],
+            }),
+        );
+
+        visit(
+            root,
+            renderVisitor(outputDirectory, {
+                standalone: true,
+                withGraphql: false,
+                withPostgres: false,
+            }),
+        );
+
+        const generatedEvent = readFileSync(join(outputDirectory, 'src/events/opened.rs'), 'utf8');
+        assert.match(generatedEvent, /pub struct OpenedEvent/);
+        assert.match(generatedEvent, /if discriminator != \[166, 172, 97, 9, 77, 76, 189, 109\]/);
+        assert.match(generatedEvent, /pub amount: u64/);
+    } finally {
+        rmSync(outputDirectory, { force: true, recursive: true });
+    }
+});
+
+test('reuses a defined type regardless of JSON key order and docs', () => {
+    const outputDirectory = mkdtempSync(join(tmpdir(), 'carbon-defined-type-reorder-'));
+
+    try {
+        const eventTag = constantValueNodeFromBytes('base16', 'a6ac61094d4cbd6d');
+        const buildPayload = () =>
+            structTypeNode([
+                structFieldTypeNode({
+                    name: 'amount',
+                    type: numberTypeNode('u64'),
+                }),
+            ]);
+        const reorderedDefinedType = {
+            ...reversedKeys(definedTypeNode({ name: 'opened', type: buildPayload() })),
+            docs: ['pre-existing type docs'],
+        };
+        const root = rootNode(
+            programWithEvents({
+                name: 'payments',
+                publicKey: '11111111111111111111111111111111',
+                definedTypes: [reorderedDefinedType],
+                events: [
+                    nativeEventNode({
+                        name: 'opened',
+                        data: hiddenPrefixTypeNode(buildPayload(), [eventTag]),
+                        discriminators: [constantDiscriminatorNode(eventTag, 0)],
+                    }),
+                ],
+                instructions: [instructionNode({ name: 'createPayment' })],
+            }),
+        );
+
+        visit(
+            root,
+            renderVisitor(outputDirectory, {
+                standalone: true,
+                withGraphql: false,
+                withPostgres: false,
+            }),
+        );
+
+        assert.equal(existsSync(join(outputDirectory, 'src/instructions/cpi_event.rs')), true);
+        const generatedEvent = readFileSync(join(outputDirectory, 'src/events/opened.rs'), 'utf8');
+        assert.match(generatedEvent, /pub amount: u64/);
+    } finally {
+        rmSync(outputDirectory, { force: true, recursive: true });
+    }
+});
+
+test('mixed classic and hidden-prefix events share the classic CPI discriminator', () => {
+    const outputDirectory = mkdtempSync(join(tmpdir(), 'carbon-mixed-shape-events-'));
+
+    try {
+        const hiddenTag = constantValueNodeFromBytes('base16', 'd116b9d754a75450');
+        const root = rootNode(
+            programWithEvents({
+                name: 'payments',
+                publicKey: '11111111111111111111111111111111',
+                events: [
+                    nativeEventNode({
+                        name: 'paymentCreated',
+                        data: structTypeNode([]),
+                        discriminators: [
+                            constantDiscriminatorNode(constantValueNodeFromBytes('base16', '01020304'), 0),
+                            constantDiscriminatorNode(constantValueNodeFromBytes('base16', '09'), 4),
+                        ],
+                    }),
+                    nativeEventNode({
+                        name: 'payoutRedirected',
+                        data: hiddenPrefixTypeNode(structTypeNode([]), [hiddenTag]),
+                        discriminators: [constantDiscriminatorNode(hiddenTag, 0)],
+                    }),
+                ],
+                instructions: [instructionNode({ name: 'createPayment' })],
+            }),
+        );
+
+        visit(
+            root,
+            renderVisitor(outputDirectory, {
+                standalone: true,
+                withGraphql: false,
+                withPostgres: false,
+            }),
+        );
+
+        const cpiEvent = readFileSync(join(outputDirectory, 'src/instructions/cpi_event.rs'), 'utf8');
+        assert.match(cpiEvent, /if discriminator != \[1, 2, 3, 4\]/);
+        assert.match(cpiEvent, /let event_data = &data\[4\.\.\]/);
+        assert.match(cpiEvent, /PaymentCreated/);
+        assert.match(cpiEvent, /PayoutRedirected/);
+    } finally {
+        rmSync(outputDirectory, { force: true, recursive: true });
+    }
+});
+
+test('defaults hidden-prefix events to the legacy Anchor CPI discriminator', () => {
+    const outputDirectory = mkdtempSync(join(tmpdir(), 'carbon-hidden-prefix-legacy-'));
+
+    try {
+        const eventTag = constantValueNodeFromBytes('base16', 'd116b9d754a75450');
+        const root = rootNode(
+            programWithEvents({
+                name: 'payments',
+                publicKey: '11111111111111111111111111111111',
+                events: [
+                    nativeEventNode({
+                        name: 'payoutRedirected',
+                        data: hiddenPrefixTypeNode(structTypeNode([]), [eventTag]),
+                        discriminators: [constantDiscriminatorNode(eventTag, 0)],
+                    }),
+                ],
+                instructions: [instructionNode({ name: 'createPayment' })],
+            }),
+        );
+
+        visit(
+            root,
+            renderVisitor(outputDirectory, {
+                standalone: true,
+                withGraphql: false,
+                withPostgres: false,
+            }),
+        );
+
+        const cpiEvent = readFileSync(join(outputDirectory, 'src/instructions/cpi_event.rs'), 'utf8');
+        assert.match(cpiEvent, /if discriminator != \[228, 69, 165, 46, 81, 203, 154, 29\]/);
+        assert.match(cpiEvent, /let event_data = &data\[8\.\.\]/);
+
+        const generatedEvent = readFileSync(join(outputDirectory, 'src/events/payout_redirected.rs'), 'utf8');
+        assert.match(generatedEvent, /if discriminator != \[209, 22, 185, 215, 84, 167, 84, 80\]/);
     } finally {
         rmSync(outputDirectory, { force: true, recursive: true });
     }
@@ -249,6 +697,20 @@ test('ignores native events that do not describe an event-CPI payload', () => {
 
 function nativeEventNode(input) {
     return { kind: 'eventNode', docs: [], ...input };
+}
+
+function reversedKeys(value) {
+    if (Array.isArray(value)) {
+        return value.map(reversedKeys);
+    }
+    if (value !== null && typeof value === 'object') {
+        return Object.fromEntries(
+            Object.keys(value)
+                .reverse()
+                .map(key => [key, reversedKeys(value[key])]),
+        );
+    }
+    return value;
 }
 
 function programWithEvents(input) {

--- a/packages/renderer/tests/native-events.test.mjs
+++ b/packages/renderer/tests/native-events.test.mjs
@@ -6,6 +6,7 @@ import test from 'node:test';
 
 import {
     constantDiscriminatorNode,
+    constantValueNode,
     constantValueNodeFromBytes,
     definedTypeNode,
     fieldDiscriminatorNode,
@@ -318,6 +319,79 @@ test('lets the eventCpiDiscriminator option override the hidden-prefix envelope'
 
         const generatedEvent = readFileSync(join(outputDirectory, 'src/events/payout_redirected.rs'), 'utf8');
         assert.match(generatedEvent, /if discriminator != \[209, 22, 185, 215, 84, 167, 84, 80\]/);
+    } finally {
+        rmSync(outputDirectory, { force: true, recursive: true });
+    }
+});
+
+test('decodes a base58 hidden-prefix discriminator according to its encoding', () => {
+    const outputDirectory = mkdtempSync(join(tmpdir(), 'carbon-base58-event-tag-'));
+
+    try {
+        // In base58, each leading "1" represents a zero byte.
+        const eventTag = constantValueNodeFromBytes('base58', '11111111');
+        const root = rootNode(
+            programWithEvents({
+                name: 'payments',
+                publicKey: '11111111111111111111111111111111',
+                events: [
+                    nativeEventNode({
+                        name: 'paymentCreated',
+                        data: hiddenPrefixTypeNode(structTypeNode([]), [eventTag]),
+                        discriminators: [constantDiscriminatorNode(eventTag, 0)],
+                    }),
+                ],
+                instructions: [instructionNode({ name: 'createPayment' })],
+            }),
+        );
+
+        visit(
+            root,
+            renderVisitor(outputDirectory, {
+                standalone: true,
+                withGraphql: false,
+                withPostgres: false,
+            }),
+        );
+
+        const generatedEvent = readFileSync(join(outputDirectory, 'src/events/payment_created.rs'), 'utf8');
+        assert.match(generatedEvent, /if discriminator != \[0, 0, 0, 0, 0, 0, 0, 0\]/);
+    } finally {
+        rmSync(outputDirectory, { force: true, recursive: true });
+    }
+});
+
+test('preserves big-endian numeric hidden-prefix discriminators', () => {
+    const outputDirectory = mkdtempSync(join(tmpdir(), 'carbon-big-endian-event-tag-'));
+
+    try {
+        const eventTag = constantValueNode(numberTypeNode('u16', 'be'), numberValueNode(0x0102));
+        const root = rootNode(
+            programWithEvents({
+                name: 'payments',
+                publicKey: '11111111111111111111111111111111',
+                events: [
+                    nativeEventNode({
+                        name: 'paymentCreated',
+                        data: hiddenPrefixTypeNode(structTypeNode([]), [eventTag]),
+                        discriminators: [constantDiscriminatorNode(eventTag, 0)],
+                    }),
+                ],
+                instructions: [instructionNode({ name: 'createPayment' })],
+            }),
+        );
+
+        visit(
+            root,
+            renderVisitor(outputDirectory, {
+                standalone: true,
+                withGraphql: false,
+                withPostgres: false,
+            }),
+        );
+
+        const generatedEvent = readFileSync(join(outputDirectory, 'src/events/payment_created.rs'), 'utf8');
+        assert.match(generatedEvent, /if discriminator != \[1, 2\]/);
     } finally {
         rmSync(outputDirectory, { force: true, recursive: true });
     }


### PR DESCRIPTION
## Problem

Two related bugs when a program's on-chain Codama IDL declares events with a single discriminator whose bytes are baked into the data type as a `hiddenPrefixTypeNode` (instead of the two-constant-discriminator layout `normalizeCodamaEvents` expects):

1. **Events silently dropped.** `normalizeCodamaEvents` returns `null` for that shape, so no `cpi_event.rs` or event pages are generated even though the IDL declares events.
2. **Emit instruction shadows CpiEvent.** When the IDL also declares the event-CPI wrapper instruction (e.g. `emitEvent` with a `u8` discriminator and an `eventAuthority` account), the generated instruction decoder matches `[disc][anything]` — its empty argument struct borsh-deserializes ignoring trailing bytes — and `try_decode_instructions!` tries `CpiEvent` last. Every event decodes as an empty wrapper instruction and is lost.

Hit in production with mainnet program `CHNLxYvVA28MJP9PrFuDXccuoGXAx7jBacfLEkahyGsX` (`paymentChannels`), whose on-chain IDL uses exactly this encoding.

## Fix

- `normalizeCodamaEvents` accepts the hidden-prefix shape: single constant discriminator at offset 0 whose bytes match the data type's hidden prefix. The event struct is the unwrapped inner type.
- Hidden-prefix events are framed with the legacy Anchor event-CPI discriminator `[228, 69, 165, 46, 81, 203, 154, 29]` by default. The wrapper instruction's dispatch discriminator is **never** used for framing: it can be a strict prefix of the wire envelope (payment-channels routes its self-CPI on byte `228` but writes the full 8-byte Anchor tag), so inferring framing from it misaligns every event.
- A new `eventCpiDiscriminator` renderer option overrides the default envelope for programs with a genuinely custom one.
- No instructions are removed from the generated decoder. `CpiEvent` is tried **first** in `try_decode_instructions!` instead: events can no longer be shadowed by the payload-free wrapper, unknown event discriminators still fall through to `EmitEvent`, and generated modules/enum variants for declared instructions are preserved.
- Every path that skips event generation now emits a `console.warn` instead of silently dropping events, including the new structural check when an event name collides with an existing defined type of a different shape. The comparison is canonical (key-order-insensitive, `docs` ignored) so reserialized IDLs are not misreported as collisions.
- The Carbon CLI exposes the override as `--event-cpi-discriminator <hex>` on `parse` and `scaffold`.

## Tests

- `frames hidden-prefix events with the full Anchor event-CPI envelope` — assertions derived from real `Opened` wire bytes (`tag | event discriminator | channel | open_slot`); also pins that `emit_event.rs` is kept and `CpiEvent` is the first `try_decode_instructions!` arm
- `lets the eventCpiDiscriminator option override the hidden-prefix envelope`
- `skips event decoding when an event collides with a defined type of a different shape` (asserts the warning)
- `defaults hidden-prefix events to the legacy Anchor CPI discriminator`
- All remaining tests unchanged and passing (12/12), including classic two-discriminator events, mixed classic/hidden-prefix programs, and the `anchorEvents` option paths
- `reuses a defined type regardless of JSON key order and docs` — regression for the canonical shape comparison
- Verified out-of-band (not committed, to leave the repo's test setup unchanged): rendered the raw on-chain `paymentChannels` IDL, compiled the generated crate against the workspace carbon crates, and drove the real wire framing through `PaymentChannelsDecoder::decode_instruction` — the 8-byte envelope decodes as `CpiEvent::Opened` with correct fields; dispatch-only 1-byte framing and unknown event discriminators fall through to `EmitEvent` instead of being lost

## Generated-output changes for existing users

- IDLs with hidden-prefix events previously produced no event output; they now produce `cpi_event.rs`, event pages, and a `CpiEvent` enum variant (additive, but breaks exhaustive matches on the instruction enum).
- `try_decode_instructions!` now tries `CpiEvent` before declared instructions; an instruction that fully matches an event-CPI payload (16-byte prefix collision) now decodes as the event.
