### PR TITLE
fix(yellowstone-grpc-datasource): back off between failed subscribe attempts

### DIFF
--- a/datasources/yellowstone-grpc-datasource/src/lib.rs
+++ b/datasources/yellowstone-grpc-datasource/src/lib.rs
@@ -84,6 +84,12 @@ fn register_yellowstone_metrics() {
 /// Default timeout for detecting stale connections (30 seconds)
 pub const DEFAULT_STREAM_TIMEOUT_SECS: u64 = 30;
 
+/// Initial delay before retrying a failed subscription attempt
+const RECONNECT_INITIAL_DELAY_MS: u64 = 100;
+
+/// Upper bound on the retry delay
+const RECONNECT_MAX_DELAY_MS: u64 = 3_000;
+
 #[derive(Debug)]
 pub struct YellowstoneGrpcGeyserClient {
     pub endpoint: String,
@@ -265,6 +271,7 @@ impl Datasource for YellowstoneGrpcGeyserClient {
             let mut last_disconnect_time: Option<DateTime<Utc>> = None;
             let mut last_slot_before_disconnect: Option<u64> = None;
             let mut last_processed_slot: u64 = 0;
+            let mut reconnect_delay = Duration::from_millis(RECONNECT_INITIAL_DELAY_MS);
 
             loop {
                 tokio::select! {
@@ -275,6 +282,7 @@ impl Datasource for YellowstoneGrpcGeyserClient {
                     result = geyser_client.subscribe_with_request(Some(subscribe_request.clone())) => {
                         match result {
                             Ok((mut subscribe_tx, mut stream)) => {
+                                reconnect_delay = Duration::from_millis(RECONNECT_INITIAL_DELAY_MS);
                                 let mut first_message_after_reconnect = last_disconnect_time.is_some();
 
                                 loop {
@@ -430,6 +438,16 @@ impl Datasource for YellowstoneGrpcGeyserClient {
                                     last_slot_before_disconnect = Some(last_processed_slot);
                                 }
 
+                                tokio::select! {
+                                    _ = cancellation_token.cancelled() => {
+                                        log::info!("Cancelling Yellowstone gRPC subscription.");
+                                        break;
+                                    }
+                                    _ = tokio::time::sleep(reconnect_delay) => {}
+                                }
+
+                                reconnect_delay = (reconnect_delay * 2)
+                                    .min(Duration::from_millis(RECONNECT_MAX_DELAY_MS));
                             }
                         }
                     }


### PR DESCRIPTION
Closes #580.

When the subscribe failed, the code logged the error and went back to the top of the loop. With no network that came to ~3,000 tries a second.

Now it waits before retrying. The wait starts at 100ms, doubles each time it fails again, stops growing at 3 seconds, and resets once a subscribe works. The sleep sits inside a `select!` with the cancellation token, so shutdown is still instant.