### PR TITLE
fix(core): decode log events shorter than eight bytes

### DIFF
--- a/crates/core/src/instruction.rs
+++ b/crates/core/src/instruction.rs
@@ -61,7 +61,6 @@ impl InstructionMetadata {
     pub fn decode_log_events<T: CarbonDeserialize>(&self) -> Vec<T> {
         self.extract_event_log_data()
             .into_iter()
-            .filter(|log| log.len() >= 8)
             .filter_map(|log| <T as CarbonDeserialize>::deserialize(&log))
             .collect()
     }
@@ -494,6 +493,39 @@ mod tests {
         let nested_instructions: NestedInstructions = instructions.into();
         assert_eq!(nested_instructions.len(), 2);
         assert_eq!(nested_instructions.0[1].inner_instructions.len(), 1);
+    }
+
+    #[test]
+    fn test_decode_log_events_accepts_payloads_under_eight_bytes() {
+        #[derive(crate::borsh::BorshDeserialize)]
+        struct TinyEvent {
+            value: u8,
+        }
+
+        impl CarbonDeserialize for TinyEvent {
+            const DISCRIMINATOR: &'static [u8] = &[9];
+
+            fn deserialize(data: &[u8]) -> Option<Self> {
+                let payload = data.strip_prefix(Self::DISCRIMINATOR)?;
+                crate::borsh::BorshDeserialize::try_from_slice(payload).ok()
+            }
+        }
+
+        let metadata = create_metadata_with_message(
+            vec![0],
+            1,
+            vec![
+                "Program CAMMCzo5YL8w4VFF8KVHrK22GGUsp5VTaW7grrKgrWqK invoke [1]".to_string(),
+                "Program data: CSo=".to_string(),
+                "Program CAMMCzo5YL8w4VFF8KVHrK22GGUsp5VTaW7grrKgrWqK success".to_string(),
+            ],
+            vec![],
+            vec![],
+        );
+
+        let events = metadata.decode_log_events::<TinyEvent>();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].value, 42);
     }
 
     #[test]


### PR DESCRIPTION
## What

Removes the `.filter(|log| log.len() >= 8)` pre-filter in `InstructionMetadata::decode_log_events` and lets `CarbonDeserialize::deserialize` decide whether a payload decodes.

## Why

The filter predates support for non-Anchor discriminators. A Codama IDL may declare an event with a one-byte discriminator and a small body, which serializes to fewer than eight bytes. Such an event decodes fine when emitted through event CPI but is silently dropped when emitted through `Program data:` logs: no error, no metric, the event just never reaches the processor.

## How

`deserialize` already rejects payloads that are too short for the discriminator (`extract_discriminator` length-checks), so the pre-filter is redundant for Anchor-style 8-byte discriminators and only harmful for shorter ones. Behavior for existing Anchor decoders is unchanged.

Not a breaking change: strictly widens the set of decodable payloads; no API change.

## Testing

New test `test_decode_log_events_accepts_payloads_under_eight_bytes` decodes a 2-byte payload (1-byte discriminator + u8 body) from a `Program data:` log. Verified it fails against the old filter. `cargo test -p carbon-core`, clippy, and fmt pass.