### PR TITLE
feat(renderer): export the event-CPI discriminator from generated crates

### DIFF
--- a/packages/renderer/templates/lib.njk
+++ b/packages/renderer/templates/lib.njk
@@ -4,6 +4,9 @@
 use solana_pubkey::Pubkey;
 pub struct {{ program.name | pascalCase }}Decoder;
 pub const PROGRAM_ID: Pubkey = solana_pubkey::Pubkey::from_str_const("{{ program.publicKey }}");
+{% if hasAnchorEvents %}
+pub const EVENT_CPI_DISCRIMINATOR: &[u8] = &[{{ eventCpiDiscriminator | join(', ') }}];
+{% endif %}
 
 pub mod accounts;
 {% if instructionsToExport.length > 0 %}

--- a/packages/renderer/tests/native-events.test.mjs
+++ b/packages/renderer/tests/native-events.test.mjs
@@ -68,6 +68,9 @@ test('renders native Codama events with their IDL-defined CPI discriminator', ()
         assert.match(generatedEvent, /pub struct PaymentCreatedEvent/);
         assert.match(generatedEvent, /if discriminator != \[9\]/);
 
+        const lib = readFileSync(join(outputDirectory, 'src/lib.rs'), 'utf8');
+        assert.match(lib, /pub const EVENT_CPI_DISCRIMINATOR: &\[u8\] = &\[1, 2, 3, 4\];/);
+
         const cargoToml = readFileSync(join(outputDirectory, 'Cargo.toml'), 'utf8');
         assert.match(cargoToml, /carbon-core = \{ version = "0\.12\.0"/);
         assert.match(cargoToml, /carbon-test-utils = "0\.12\.0"/);
@@ -167,6 +170,9 @@ test('keeps the anchorEvents renderer option backward compatible', () => {
         assert.match(cpiEvent, /if discriminator != \[228, 69, 165, 46, 81, 203, 154, 29\]/);
         assert.match(cpiEvent, /let event_data = &data\[8\.\.\]/);
         assert.doesNotMatch(cpiEvent, /NativePaymentCreated/);
+
+        const lib = readFileSync(join(outputDirectory, 'src/lib.rs'), 'utf8');
+        assert.match(lib, /pub const EVENT_CPI_DISCRIMINATOR: &\[u8\] = &\[228, 69, 165, 46, 81, 203, 154, 29\];/);
     } finally {
         rmSync(outputDirectory, { force: true, recursive: true });
     }
@@ -205,6 +211,9 @@ test('keeps an explicit empty anchorEvents option as an event opt-out', () => {
         );
 
         assert.equal(existsSync(join(outputDirectory, 'src/instructions/cpi_event.rs')), false);
+
+        const lib = readFileSync(join(outputDirectory, 'src/lib.rs'), 'utf8');
+        assert.doesNotMatch(lib, /EVENT_CPI_DISCRIMINATOR/);
     } finally {
         rmSync(outputDirectory, { force: true, recursive: true });
     }


### PR DESCRIPTION
## What

Generated crates now expose the event-CPI envelope as a public constant in `src/lib.rs`, next to `PROGRAM_ID`, whenever events are generated:

```rust
pub const EVENT_CPI_DISCRIMINATOR: &[u8] = &[228, 69, 165, 46, 81, 203, 154, 29];
```

## Why

The renderer reads the event-CPI envelope from the IDL (falling back to the legacy Anchor tag) but emits it only inline inside `CpiEvent::decode`. Log-emitted events arrive without that envelope, so a consumer has to prepend it before calling the generated `CpiEvent::decode`, and the only way to know which bytes to prepend is to hardcode a guess. For programs whose IDL declares a custom envelope, that guess is wrong and log decoding silently returns nothing while CPI emission keeps working.

## How

`lib.njk` renders the constant from the same `eventCpiDiscriminator` value `CpiEvent::decode` is generated from, only when events exist. `CpiEvent::decode` itself is unchanged. Purely additive to generated output; no breaking change.

Complements #578 (which adds an `--event-cpi-discriminator` override); the two are independent and can merge in either order.

## Testing

Renderer suite assertions: IDL-declared envelope, legacy Anchor default via the `anchorEvents` option, and absence of the constant when events are opted out. All tests pass.