### PR TITLE
fix(core): skip inner instructions with invalid stack heights

### DIFF
--- a/crates/core/src/transformers.rs
+++ b/crates/core/src/transformers.rs
@@ -125,7 +125,16 @@ fn process_instructions<F1, F2>(
                     let mut prev_height = 0;
 
                     for inner_inst in &inner_tx.instructions {
-                        let stack_height = inner_inst.stack_height.unwrap_or(1) as usize;
+                        let Some(stack_height) = validated_stack_height(inner_inst.stack_height)
+                        else {
+                            log::warn!(
+                                "invalid inner instruction stack height ({:?}) in transaction {} at instruction {}, dropping the remaining inner instructions of this group",
+                                inner_inst.stack_height,
+                                transaction_metadata.signature,
+                                inner_tx.index,
+                            );
+                            break;
+                        };
                         if stack_height > prev_height {
                             path_stack[stack_height - 1] = 0;
                         } else {
@@ -152,6 +161,15 @@ fn process_instructions<F1, F2>(
                 }
             }
         }
+    }
+}
+
+fn validated_stack_height(stack_height: Option<u32>) -> Option<usize> {
+    match stack_height {
+        Some(height) if (2..=MAX_INSTRUCTION_STACK_DEPTH as u32).contains(&height) => {
+            Some(height as usize)
+        }
+        _ => None,
     }
 }
 
@@ -633,6 +651,66 @@ mod tests {
         assert_eq!(nested_instructions[0].inner_instructions.len(), 0);
         assert_eq!(nested_instructions[1].inner_instructions.len(), 4);
         assert_eq!(nested_instructions[2].inner_instructions.len(), 0);
+    }
+
+    #[test]
+    fn test_extract_instructions_skips_inner_group_after_invalid_stack_height() {
+        let build_update = |stack_heights: Vec<Option<u32>>| {
+            let payer = Pubkey::new_unique();
+            let program = Pubkey::new_unique();
+            let instruction = CompiledInstruction {
+                program_id_index: 1,
+                accounts: vec![0],
+                data: vec![],
+            };
+            TransactionUpdate {
+                signature: Signature::default(),
+                transaction: VersionedTransaction {
+                    signatures: vec![Signature::default()],
+                    message: VersionedMessage::Legacy(Message {
+                        header: MessageHeader::default(),
+                        account_keys: vec![payer, program],
+                        recent_blockhash: Hash::default(),
+                        instructions: vec![instruction.clone()],
+                    }),
+                },
+                meta: TransactionStatusMeta {
+                    inner_instructions: Some(vec![InnerInstructions {
+                        index: 0,
+                        instructions: stack_heights
+                            .into_iter()
+                            .map(|stack_height| InnerInstruction {
+                                instruction: instruction.clone(),
+                                stack_height,
+                            })
+                            .collect(),
+                    }]),
+                    ..Default::default()
+                },
+                is_vote: false,
+                slot: 1,
+                index: None,
+                block_time: None,
+                block_hash: None,
+            }
+        };
+        let extract = |stack_heights: Vec<Option<u32>>| {
+            extract_instructions_with_metadata(
+                &Arc::new(TransactionMetadata::default()),
+                &build_update(stack_heights),
+            )
+            .expect("extract instructions with metadata")
+        };
+
+        assert_eq!(extract(vec![None]).len(), 1);
+        assert_eq!(extract(vec![Some(1)]).len(), 1);
+        assert_eq!(extract(vec![Some(6)]).len(), 1);
+        assert_eq!(extract(vec![Some(2)]).len(), 2);
+
+        let partial = extract(vec![Some(2), None, Some(2)]);
+        assert_eq!(partial.len(), 2);
+        assert_eq!(partial[0].0.absolute_path, vec![0]);
+        assert_eq!(partial[1].0.absolute_path, vec![0, 0]);
     }
 
     #[test]


### PR DESCRIPTION
## What

`extract_instructions_with_metadata` validates inner instruction stack heights instead of defaulting a missing one to depth 1. On a height that is absent or outside `2..=MAX_INSTRUCTION_STACK_DEPTH`, it keeps the top-level instruction, logs a warning with the signature and instruction index, and drops the rest of that inner-instruction group.

## Why

`inner_inst.stack_height.unwrap_or(1)` gives an inner instruction the same `absolute_path` as a top-level instruction. `DeduplicationFilter` keys on `(signature, absolute_path)` and inserts for every instruction it sees, decoded or not, so the colliding top-level instruction claims the key first and the nested instruction is silently rejected: no log, no metric. Heights of 0 or above `MAX_INSTRUCTION_STACK_DEPTH` panic on the `path_stack` index, so a nonconforming datasource can crash the pipeline.

Both wire formats permit the field to be absent: proto3 `optional` over Yellowstone, nullable `stackHeight` over JSON-RPC (validators record it since Solana v1.14.6, so this mostly affects historical backfills and nonconforming providers).

## How

Once one height in a group is unknown, the nesting of everything after it is unknowable, and guessing a depth is what caused the defect, so the remainder of the group is dropped with a `log::warn!`. Not a breaking change: no API change, and no transaction that previously extracted fails now; pre-v1.14.6 backfills keep decoding top-level instructions.

Considered and rejected: failing the transaction with a new `Error` variant. That would add a variant to the exhaustive public `Error` enum (semver-major) and error transactions that previously processed.

## Testing

New test covers heights `None`, `Some(1)`, `Some(6)` (inner dropped, top-level kept), `Some(2)` (fully extracted), and a mixed group `[Some(2), None, Some(2)]` (first inner kept with the correct path, remainder dropped). `cargo test -p carbon-core`, clippy, and fmt pass.