### PR TITLE
feat(laserstream-config): Adds optional from_slot for recovery on start

### DIFF
--- a/datasources/helius-laserstream-datasource/src/lib.rs
+++ b/datasources/helius-laserstream-datasource/src/lib.rs
@@ -108,6 +108,7 @@ pub struct LaserStreamClientConfig {
     pub tls_config: Option<ClientTlsConfig>,
     pub tcp_nodelay: Option<bool>,
     pub replay_enabled: bool,
+    pub from_slot: Option<u64>,
 }
 
 impl Default for LaserStreamClientConfig {
@@ -120,6 +121,7 @@ impl Default for LaserStreamClientConfig {
             tls_config: None,
             tcp_nodelay: None,
             replay_enabled: true,
+            from_slot: None,
         }
     }
 }
@@ -164,6 +166,7 @@ impl LaserStreamClientConfig {
         tls_config: Option<ClientTlsConfig>,
         tcp_nodelay: Option<bool>,
         replay_enabled: bool,
+        from_slot: Option<u64>,
     ) -> Self {
         LaserStreamClientConfig {
             compression,
@@ -173,6 +176,7 @@ impl LaserStreamClientConfig {
             tls_config,
             tcp_nodelay,
             replay_enabled,
+            from_slot,
         }
     }
 
@@ -255,7 +259,7 @@ impl Datasource for LaserStreamGeyserClient {
                 commitment: commitment.map(|x| x as i32),
                 accounts_data_slice: vec![],
                 ping: None,
-                from_slot: None,
+                from_slot: geyser_config.from_slot,
             };
 
             let internal_slot_sub_id = if replay_enabled {

--- a/datasources/helius-laserstream-datasource/src/lib.rs
+++ b/datasources/helius-laserstream-datasource/src/lib.rs
@@ -158,6 +158,7 @@ impl LaserStreamGeyserClient {
 }
 
 impl LaserStreamClientConfig {
+    #[allow(clippy::too_many_arguments)]
     pub const fn new(
         compression: Option<CompressionEncoding>,
         connect_timeout: Option<Duration>,

--- a/examples/yellowstone-grpc/src/variants.rs
+++ b/examples/yellowstone-grpc/src/variants.rs
@@ -44,6 +44,7 @@ pub fn laserstream(
         None,
         None,
         true,
+        None,
     );
 
     LaserStreamGeyserClient::new(


### PR DESCRIPTION
When booting up an indexer, I wanted to be able to hydrate events from a particular slot, but the `LaserStreamClientConfig` did not have configurability for this.

Added 
- `from_slot: Option<u64>` to the `LaserStreamClientConfig` 
- `impl Default` sets it to `None`
- Inside `datasources/helius-laserstream-datasource/src/lib.rs` where we implement `consume()` and spawn the thread, `SubscribeRequest` now takes the `from_slot: geyser_config.from_slot` rather than always `None`.

This allows re-reading from a given slot on startup, rather than just during recovery.