### PR TITLE
feat: add HyperSync datasource

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ dependencies = [
  "solana-lattice-hash",
  "solana-measure",
  "solana-metrics",
- "strum",
+ "strum 0.24.1",
  "symlink",
  "tar",
  "tempfile",
@@ -276,6 +276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if 1.0.4",
+ "const-random",
  "getrandom 0.3.4",
  "once_cell",
  "version_check",
@@ -366,7 +367,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -377,7 +378,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -661,6 +662,221 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "arrow"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bd47f2a6ddc39244bd722a27ee5da66c03369d087b9e024eafdb03e98b98ea7"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-csv",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c7bbd679c5418b8639b92be01f361d60013c4906574b578b77b63c78356594c"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8a4ab47b3f3eac60f7fd31b81e9028fda018607bcc63451aca4f2b755269862"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half 2.7.1",
+ "hashbrown 0.16.1",
+ "num-complex 0.4.6",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d18b89b4c4f4811d0858175e79541fe98e33e18db3b011708bc287b1240593f"
+dependencies = [
+ "bytes",
+ "half 2.7.1",
+ "num-bigint 0.4.6",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "722b5c41dd1d14d0a879a1bce92c6fe33f546101bb2acce57a209825edd075b3"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "half 2.7.1",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-csv"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ddb80a4848e03b1655af496d5ac2563a779e5742fcb48f2ca2e089c9cd2197"
+dependencies = [
+ "arrow-array",
+ "arrow-cast",
+ "arrow-schema",
+ "chrono",
+ "csv",
+ "csv-core",
+ "regex",
+]
+
+[[package]]
+name = "arrow-data"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1683705c63dcf0d18972759eda48489028cbbff67af7d6bef2c6b7b74ab778a"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half 2.7.1",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf72d04c07229fbf4dbebe7145cac37d7cf7ec582fe705c6b92cb314af096ab"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-json"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84a905f41fedfcd7679813c89a61dc369c0f932b27aa8dcc6aa051cc781a97d"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half 2.7.1",
+ "indexmap 2.12.1",
+ "itoa",
+ "lexical-core",
+ "memchr",
+ "num-traits",
+ "ryu",
+ "serde_core",
+ "serde_json",
+ "simdutf8",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "082342947d4e5a2bcccf029a0a0397e21cb3bb8421edd9571d34fb5dd2670256"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a931b520a2a5e22033e01a6f2486b4cdc26f9106b759abeebc320f125e94d7"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half 2.7.1",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4cf0d4a6609679e03002167a61074a21d7b1ad9ea65e462b2c0a97f8a3b2bc6"
+
+[[package]]
+name = "arrow-select"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b320d86a9806923663bb0fd9baa65ecaba81cb0cd77ff8c1768b9716b4ef891"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b493e99162e5764077e7823e50ba284858d365922631c7aaefe9487b1abd02c2"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
 
 [[package]]
 name = "ascii"
@@ -1667,6 +1883,25 @@ dependencies = [
  "uuid",
  "yellowstone-grpc-client",
  "yellowstone-grpc-proto",
+]
+
+[[package]]
+name = "carbon-hypersync-datasource"
+version = "1.0.0"
+dependencies = [
+ "async-trait",
+ "carbon-core",
+ "hypersync-client-solana",
+ "hypersync-solana-net-types",
+ "log",
+ "solana-hash 3.1.0",
+ "solana-message",
+ "solana-pubkey 3.0.0",
+ "solana-signature",
+ "solana-transaction",
+ "solana-transaction-status",
+ "tokio",
+ "tokio-util 0.7.17",
 ]
 
 [[package]]
@@ -3132,6 +3367,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "const-str"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3312,6 +3567,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3489,7 +3765,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -3693,6 +3969,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "eager"
@@ -3905,7 +4187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4058,6 +4340,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags 2.10.0",
+ "rustc_version",
+]
 
 [[package]]
 name = "flate2"
@@ -4457,6 +4749,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if 1.0.4",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
+]
+
+[[package]]
 name = "halfbrown"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4835,6 +5139,7 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-util",
  "rustls 0.23.35",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -4920,6 +5225,50 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
+]
+
+[[package]]
+name = "hypersync-client-solana"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be5d9c69d5c04fb9951dfe0eb73cbe677335321f31f5587a923883e9e5f3117"
+dependencies = [
+ "anyhow",
+ "arrow",
+ "borsh",
+ "bs58",
+ "futures 0.3.31",
+ "hypersync-solana-net-types",
+ "hypersync-solana-schema",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hypersync-solana-net-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ae897620fa0eea4e950a3bb98edb2f058e514017ca5362530455a9af1de2de"
+dependencies = [
+ "bs58",
+ "schemars",
+ "serde",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "hypersync-solana-schema"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f3d4e6ddfe70e881ea37aefe6a4f317c78a29ab093cfd8cdd877b1397ee6bee"
+dependencies = [
+ "arrow",
 ]
 
 [[package]]
@@ -5608,6 +5957,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6089,7 +6495,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
 dependencies = [
  "num-bigint 0.2.6",
- "num-complex",
+ "num-complex 0.2.4",
  "num-integer",
  "num-iter",
  "num-rational",
@@ -6140,6 +6546,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
 dependencies = [
  "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -7448,6 +7863,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.35",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -7675,7 +8091,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7755,7 +8171,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7823,6 +8239,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -7983,7 +8424,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
- "half",
+ "half 1.8.3",
  "serde",
 ]
 
@@ -8005,6 +8446,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.112",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -9709,8 +10161,8 @@ dependencies = [
  "solana-vote",
  "solana-vote-program",
  "static_assertions",
- "strum",
- "strum_macros",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
  "tar",
  "tempfile",
  "thiserror 2.0.17",
@@ -10656,8 +11108,8 @@ dependencies = [
  "solana-vote-program",
  "spl-generic-token",
  "static_assertions",
- "strum",
- "strum_macros",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
  "symlink",
  "tempfile",
  "thiserror 2.0.17",
@@ -12442,8 +12894,14 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.24.3",
 ]
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 
 [[package]]
 name = "strum_macros"
@@ -12456,6 +12914,18 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -12486,6 +12956,17 @@ name = "syn"
 version = "2.0.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21f182278bf2d2bcb3c88b1b08a37df029d71ce3d3ae26168e3c653b213b99d4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12599,7 +13080,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12712,6 +13193,15 @@ dependencies = [
  "unicode-normalization",
  "wasm-bindgen",
  "zeroize",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -13696,7 +14186,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ carbon-helius-atlas-ws-datasource = { path = "datasources/helius-atlas-ws-dataso
 carbon-helius-gpa-v2-datasource = { path = "datasources/helius-gpa-v2-datasource", version = "1.0.0" }
 carbon-helius-gtfa-datasource = { path = "datasources/helius-gtfa-datasource", version = "1.0.0" }
 carbon-helius-laserstream-datasource = { path = "datasources/helius-laserstream-datasource", version = "1.0.0" }
+carbon-hypersync-datasource = { path = "datasources/hypersync-datasource", version = "1.0.0" }
 carbon-jetstreamer-datasource = { path = "datasources/jetstreamer-datasource", version = "1.0.0" }
 carbon-jito-shredstream-grpc-datasource = { path = "datasources/jito-shredstream-grpc-datasource", version = "1.0.0" }
 carbon-rpc-block-crawler-datasource = { path = "datasources/rpc-block-crawler-datasource", version = "1.0.0" }

--- a/datasources/hypersync-datasource/Cargo.toml
+++ b/datasources/hypersync-datasource/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "carbon-hypersync-datasource"
+description = "Carbon HyperSync Datasource"
+license = { workspace = true }
+version = "1.0.0"
+edition = { workspace = true }
+readme = "README.md"
+repository = { workspace = true }
+# hypersync-client-solana pulls arrow 57, whose MSRV is above the workspace 1.82.
+rust-version = "1.85"
+keywords = ["solana", "indexer", "hypersync", "datasource"]
+categories = ["encoding"]
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+async-trait = { workspace = true }
+carbon-core = { workspace = true }
+hypersync-client-solana = "0.2.0"
+hypersync-solana-net-types = "0.2.0"
+log = { workspace = true }
+solana-hash = { workspace = true }
+solana-message = { workspace = true }
+solana-pubkey = { workspace = true }
+solana-signature = { workspace = true }
+solana-transaction = { workspace = true }
+solana-transaction-status = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true }

--- a/datasources/hypersync-datasource/README.md
+++ b/datasources/hypersync-datasource/README.md
@@ -37,11 +37,11 @@ Yellowstone or block-crawler source produces.
 | `carbon-jetstreamer-datasource` | genesis to head minus ~2 epochs | client-side, after download | whole-chain bytes for the range |
 | `carbon-rpc-block-crawler-datasource` | RPC retention | client-side, after download | one `getBlock` per slot |
 | `carbon-rpc-transaction-crawler-datasource` | RPC retention | server-side by address | one `getTransaction` per signature |
-| this crate | last ~5 months (public endpoint) | server-side by program | matched transactions only |
+| this crate | recent history, growing with demand | server-side by program | matched transactions only |
 
 The natural composition for deep history is Jetstreamer below the HyperSync floor and this
-datasource above it; the archive behind Jetstreamer lags the head by roughly two epochs, which
-is exactly the window HyperSync serves.
+datasource above it; the archive behind Jetstreamer lags the head by roughly two epochs, a
+window HyperSync serves. Envio is actively extending the backfill depth based on user demand.
 
 ## Fidelity limits
 

--- a/datasources/hypersync-datasource/README.md
+++ b/datasources/hypersync-datasource/README.md
@@ -1,0 +1,61 @@
+# Carbon HyperSync Datasource
+
+Bounded historical backfill over [HyperSync](https://docs.envio.dev/docs/HyperSync/overview),
+Envio's columnar Solana archive, with the program filter pushed into the server. Only matched
+transactions cross the network: for a program appearing in a few percent of transactions this
+moves one to two orders of magnitude fewer bytes than crawling blocks and filtering client-side.
+
+```rust
+use carbon_hypersync_datasource::HyperSyncDatasource;
+use carbon_pumpfun_decoder::{PumpfunDecoder, PROGRAM_ID as PUMPFUN};
+
+let datasource = HyperSyncDatasource::new_mainnet_history(
+    std::env::var("HYPERSYNC_TOKEN").ok(),
+    430_000_000,          // from_slot, inclusive
+    430_001_000,          // to_slot, exclusive
+    vec![PUMPFUN],
+);
+
+carbon_core::pipeline::Pipeline::builder()
+    .datasource(datasource)
+    .instruction(PumpfunDecoder, MyProcessor)
+    .build()?
+    .run()
+    .await?;
+```
+
+The range runs to completion and the pipeline shuts down cleanly, like
+`carbon-jetstreamer-datasource`. Transactions are delivered complete: every instruction of a
+matched transaction is fetched and reassembled, with inner instructions regrouped from the
+archive's exact CPI paths, so instruction nesting and `absolute_path` values reproduce what a
+Yellowstone or block-crawler source produces.
+
+## Where it fits among the backfill sources
+
+| Source | Reach | Filtering | Cost profile |
+|---|---|---|---|
+| `carbon-jetstreamer-datasource` | genesis to head minus ~2 epochs | client-side, after download | whole-chain bytes for the range |
+| `carbon-rpc-block-crawler-datasource` | RPC retention | client-side, after download | one `getBlock` per slot |
+| `carbon-rpc-transaction-crawler-datasource` | RPC retention | server-side by address | one `getTransaction` per signature |
+| this crate | last ~5 months (public endpoint) | server-side by program | matched transactions only |
+
+The natural composition for deep history is Jetstreamer below the HyperSync floor and this
+datasource above it; the archive behind Jetstreamer lags the head by roughly two epochs, which
+is exactly the window HyperSync serves.
+
+## Fidelity limits
+
+Stated in full in the crate docs; the short list:
+
+- Only **successful** transactions are served (the archive stores no instruction rows for failed
+  ones; the block crawler also skips failed transactions).
+- Vote transactions are excluded, and `TransactionUpdate.index` is the dense non-vote rank.
+- The message header is synthesized (`num_required_signatures` from the signature count, readonly
+  counts zero), so `AccountMeta` writability flags are approximate. No decoder in this repository
+  reads them.
+- `meta.log_messages`, balances, token balances, `return_data` and rewards are not populated in v1.
+
+## Environment
+
+The public endpoint requires a bearer token, free at <https://envio.dev>. Pass it as
+`bearer_token`; the example reads `HYPERSYNC_TOKEN`.

--- a/datasources/hypersync-datasource/src/lib.rs
+++ b/datasources/hypersync-datasource/src/lib.rs
@@ -1,0 +1,842 @@
+//! HyperSync datasource: bounded historical backfill with server-side
+//! filtering.
+//!
+//! [HyperSync](https://docs.envio.dev/docs/HyperSync/overview) is Envio's
+//! columnar Solana archive. Unlike the RPC crawlers and the Jetstreamer
+//! archive reader, which download every transaction in the range and filter
+//! client-side, HyperSync pushes the program filter into the server, so only
+//! the matched transactions cross the network. For a program that appears in
+//! a few percent of transactions this reduces bytes moved by one to two
+//! orders of magnitude.
+//!
+//! The datasource is bounded, like `carbon-jetstreamer-datasource`: give it a
+//! `[from_slot, to_slot)` range and a set of program ids, and it runs the
+//! range to completion, then lets the pipeline shut down cleanly.
+//!
+//! # How it fetches
+//!
+//! Two queries per page, so that decoders see complete transactions:
+//!
+//! 1. Filter `instruction_calls` by `executing_account` (the program ids) and
+//!    collect the matching transaction ids for the page's slot window.
+//! 2. Re-query those transaction ids with no instruction filter. HyperSync
+//!    hydrates every instruction of each matched transaction, plus the
+//!    transaction row (account keys, address-lookup-table expansions,
+//!    signatures, fee) and the block row (blockhash, block time).
+//!
+//! Each transaction is then reassembled into a `TransactionUpdate`: compiled
+//! instructions are rebuilt from the stored per-instruction account index
+//! lists, and inner instructions are regrouped from the stored CPI paths with
+//! `stack_height = path.len()`, so `carbon-core`'s nesting reconstruction
+//! reproduces the original instruction tree exactly.
+//!
+//! # Fidelity limits, stated plainly
+//!
+//! - **History window.** The public endpoint serves roughly the last five
+//!   months (floor around slot 403,000,000 as of August 2026). Below the
+//!   floor, compose with `carbon-jetstreamer-datasource`, which reaches
+//!   genesis but lags the head by about two epochs; this datasource covers
+//!   exactly the window Jetstreamer cannot.
+//! - **Failed transactions are not served.** The archive stores no
+//!   instruction rows for them, so this datasource only emits successful
+//!   transactions. (`carbon-rpc-block-crawler-datasource` also skips failed
+//!   transactions, so pipelines behave identically across the two.)
+//! - **Vote transactions are excluded at ingest**, and
+//!   `TransactionUpdate.index` is therefore the dense rank over non-vote
+//!   transactions of the slot, not the original block position.
+//! - **The message header is synthesized.** `num_required_signatures` is
+//!   recovered from the signature count; the readonly counts are set to zero,
+//!   so `is_writable` / `is_signer` on `AccountMeta` are approximations. No
+//!   decoder in this repository reads them (verified against all 63 decoder
+//!   crates); processors that need exact flags should not rely on them.
+//! - `meta.log_messages`, `meta.pre/post_balances`, token balances,
+//!   `return_data` and per-transaction rewards are not populated in v1.
+//!   `recent_blockhash` is populated when the archive serves it and is
+//!   otherwise `Hash::default()`. (`carbon-jetstreamer-datasource` similarly
+//!   leaves `block_time` and `block_hash` unset; both are populated here.)
+
+use {
+    async_trait::async_trait,
+    carbon_core::{
+        datasource::{Datasource, DatasourceId, TransactionUpdate, Update, UpdateType},
+        error::{CarbonResult, Error},
+    },
+    hypersync_client_solana::{
+        config::ClientConfig,
+        simple_types::{InstructionCall, SolanaResponse, Transaction as HsTransaction},
+        Client,
+    },
+    hypersync_solana_net_types::{
+        field_selection::{BlockField, InstructionField, SolanaFieldSelection, TransactionField},
+        query::{InstructionSelection, SolanaQuery, TransactionSelection},
+        Address as HsAddress, Signature as HsSignature,
+    },
+    solana_hash::Hash,
+    solana_message::{
+        compiled_instruction::CompiledInstruction,
+        v0::{LoadedAddresses, Message as MessageV0},
+        MessageHeader, VersionedMessage,
+    },
+    solana_pubkey::Pubkey,
+    solana_signature::Signature,
+    solana_transaction::versioned::VersionedTransaction,
+    solana_transaction_status::{InnerInstruction, InnerInstructions, TransactionStatusMeta},
+    std::{
+        collections::{BTreeMap, HashMap},
+        sync::{
+            atomic::{AtomicU64, Ordering},
+            Arc,
+        },
+        time::Duration,
+    },
+    tokio::sync::mpsc::Sender,
+    tokio_util::sync::CancellationToken,
+};
+
+/// Envio's public Solana mainnet archive endpoint. Requires a bearer token
+/// (free at <https://envio.dev>).
+pub const MAINNET_HISTORY_URL: &str = "https://solana-mainnet-history.hypersync.xyz";
+
+/// Solana's maximum CPI depth; instruction paths deeper than this are
+/// malformed and skipped rather than fed into `carbon-core`'s fixed-size
+/// nesting stack.
+const MAX_STACK_DEPTH: usize = 5;
+
+/// How many transaction ids to put in one hydration request.
+const ID_CHUNK: usize = 1_000;
+
+/// Consecutive non-advancing pages tolerated before erroring out.
+const MAX_STALLS: u32 = 5;
+
+/// Counters the datasource increments while it runs; read them after the
+/// pipeline finishes for throughput accounting.
+#[derive(Debug, Default)]
+pub struct HyperSyncStats {
+    /// Completed slot pages (pass 1 windows).
+    pub pages: AtomicU64,
+    /// HTTP queries issued (both passes).
+    pub requests: AtomicU64,
+    /// Sum of raw response bytes across all queries.
+    pub response_bytes: AtomicU64,
+    /// `TransactionUpdate`s emitted.
+    pub transactions: AtomicU64,
+    /// Instruction rows contained in emitted transactions (top-level + inner).
+    pub instructions: AtomicU64,
+}
+
+/// Bounded historical backfill over a HyperSync archive, filtered server-side
+/// by program id.
+pub struct HyperSyncDatasource {
+    pub url: String,
+    pub bearer_token: Option<String>,
+    /// Inclusive start slot.
+    pub from_slot: u64,
+    /// Exclusive end slot.
+    pub to_slot: u64,
+    /// Emit every transaction containing at least one instruction (top-level
+    /// or CPI) executed by one of these programs.
+    pub programs: Vec<Pubkey>,
+    /// Cap on matched transactions per page, which bounds the id list carried
+    /// into the hydration pass.
+    pub max_transactions_per_page: usize,
+    /// Number of concurrent workers, each owning a contiguous stripe of the
+    /// slot range. Like `carbon-jetstreamer-datasource`'s `threads`, going
+    /// above 1 gives up cross-stripe delivery order, which carbon-core does
+    /// not guarantee anyway (updates from concurrent datasources interleave).
+    pub concurrency: usize,
+    stats: Arc<HyperSyncStats>,
+}
+
+impl HyperSyncDatasource {
+    pub fn new(
+        url: String,
+        bearer_token: Option<String>,
+        from_slot: u64,
+        to_slot: u64,
+        programs: Vec<Pubkey>,
+    ) -> Self {
+        Self {
+            url,
+            bearer_token,
+            from_slot,
+            to_slot,
+            programs,
+            max_transactions_per_page: 2_000,
+            concurrency: 10,
+            stats: Arc::new(HyperSyncStats::default()),
+        }
+    }
+
+    /// Convenience constructor against Envio's public mainnet archive,
+    /// mirroring `JetstreamerDatasource::new_with_old_faithful_mainnet`.
+    pub fn new_mainnet_history(
+        bearer_token: Option<String>,
+        from_slot: u64,
+        to_slot: u64,
+        programs: Vec<Pubkey>,
+    ) -> Self {
+        Self::new(
+            MAINNET_HISTORY_URL.to_string(),
+            bearer_token,
+            from_slot,
+            to_slot,
+            programs,
+        )
+    }
+
+    /// Handle to the run counters; clone before moving the datasource into
+    /// the pipeline.
+    pub fn stats(&self) -> Arc<HyperSyncStats> {
+        Arc::clone(&self.stats)
+    }
+
+    fn client(&self) -> CarbonResult<Client> {
+        Client::new(ClientConfig {
+            url: self.url.clone(),
+            bearer_token: self.bearer_token.clone(),
+            ..ClientConfig::default()
+        })
+        .map_err(|e| Error::Custom(format!("hypersync client: {e}")))
+    }
+}
+
+/// Shared context for the range workers: one HTTP client (cheap to clone,
+/// shares its rate-limit state), the resolved program filter, and the run
+/// counters.
+struct StripeContext {
+    client: Client,
+    programs: Vec<HsAddress>,
+    max_transactions_per_page: usize,
+    stats: Arc<HyperSyncStats>,
+}
+
+impl StripeContext {
+    async fn get(&self, query: &SolanaQuery) -> CarbonResult<SolanaResponse> {
+        let response = self
+            .client
+            .get(query)
+            .await
+            .map_err(|e| Error::Custom(format!("hypersync query: {e}")))?;
+        self.stats.requests.fetch_add(1, Ordering::Relaxed);
+        self.stats
+            .response_bytes
+            .fetch_add(response.response_bytes as u64, Ordering::Relaxed);
+        Ok(response)
+    }
+
+    /// Pass 1: which transactions in `[cursor, to)` touch the programs.
+    /// Returns `(ids, next_slot)`.
+    async fn matched_ids(&self, cursor: u64, to: u64) -> CarbonResult<(Vec<HsSignature>, u64)> {
+        let query = SolanaQuery {
+            from_slot: cursor,
+            to_slot: Some(to),
+            instruction_calls: vec![InstructionSelection {
+                executing_account: self.programs.clone(),
+                ..Default::default()
+            }],
+            field_selection: SolanaFieldSelection {
+                // Slim both tables: identity column only on the filtered
+                // table, identity + id on the hydrated transactions.
+                instruction_call: vec![InstructionField::Slot],
+                transaction: vec![
+                    TransactionField::Slot,
+                    TransactionField::TransactionIndex,
+                    TransactionField::TransactionId,
+                ],
+                ..Default::default()
+            },
+            max_num_transactions: Some(self.max_transactions_per_page),
+            ..Default::default()
+        };
+        let response = self.get(&query).await?;
+        let ids = response
+            .transactions
+            .iter()
+            .filter_map(|t| t.transaction_id)
+            .collect();
+        Ok((ids, response.next_slot))
+    }
+
+    /// Pass 2: hydrate every instruction of the matched transactions in
+    /// `[from, to)`, plus transaction and block rows.
+    async fn hydrate(&self, from: u64, to: u64, ids: &[HsSignature]) -> CarbonResult<Bundles> {
+        let mut bundles = Bundles::default();
+        for chunk in ids.chunks(ID_CHUNK) {
+            let mut cursor = from;
+            while cursor < to {
+                let query = SolanaQuery {
+                    from_slot: cursor,
+                    to_slot: Some(to),
+                    transactions: vec![TransactionSelection {
+                        transaction_id: chunk.to_vec(),
+                        ..Default::default()
+                    }],
+                    field_selection: SolanaFieldSelection {
+                        instruction_call: vec![
+                            InstructionField::Slot,
+                            InstructionField::TransactionIndex,
+                            InstructionField::InstructionAddress,
+                            InstructionField::ExecutingAccount,
+                            InstructionField::ExecutingAccountIndex,
+                            InstructionField::AccountArguments,
+                            InstructionField::AccountIndexArguments,
+                            InstructionField::Data,
+                        ],
+                        transaction: vec![
+                            TransactionField::Slot,
+                            TransactionField::TransactionIndex,
+                            TransactionField::TransactionId,
+                            TransactionField::Signatures,
+                            TransactionField::FeePayer,
+                            TransactionField::Fee,
+                            TransactionField::ComputeUnitsConsumed,
+                            TransactionField::AccountKeys,
+                            TransactionField::RecentBlockhash,
+                            TransactionField::LoadedAddressesWritable,
+                            TransactionField::LoadedAddressesReadonly,
+                        ],
+                        block: vec![
+                            BlockField::Slot,
+                            BlockField::Blockhash,
+                            BlockField::BlockTime,
+                        ],
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                };
+                let response = self.get(&query).await?;
+                bundles.absorb(response.transactions, response.instruction_calls);
+                for block in &response.blocks {
+                    if let Some(slot) = block.slot {
+                        bundles
+                            .blocks
+                            .insert(slot, (block.blockhash, block.block_time));
+                    }
+                }
+                if response.next_slot <= cursor {
+                    return Err(Error::Custom(format!(
+                        "hydration cursor stalled at slot {cursor}"
+                    )));
+                }
+                cursor = response.next_slot;
+            }
+        }
+        Ok(bundles)
+    }
+}
+
+/// Rows of one hydration window, grouped for assembly.
+#[derive(Default)]
+struct Bundles {
+    transactions: BTreeMap<(u64, u32), HsTransaction>,
+    instructions: BTreeMap<(u64, u32), Vec<InstructionCall>>,
+    blocks: HashMap<u64, (Option<hypersync_solana_net_types::Hash>, Option<i64>)>,
+}
+
+impl Bundles {
+    fn absorb(&mut self, transactions: Vec<HsTransaction>, instructions: Vec<InstructionCall>) {
+        for tx in transactions {
+            if let (Some(slot), Some(index)) = (tx.slot, tx.transaction_index) {
+                self.transactions.insert((slot, index), tx);
+            }
+        }
+        for row in instructions {
+            if let (Some(slot), Some(index)) = (row.slot, row.transaction_index) {
+                self.instructions
+                    .entry((slot, index))
+                    .or_default()
+                    .push(row);
+            }
+        }
+    }
+}
+
+/// One worker's page loop over `[from, to)`.
+async fn run_stripe(
+    context: Arc<StripeContext>,
+    from: u64,
+    to: u64,
+    id: DatasourceId,
+    sender: Sender<(Update, DatasourceId)>,
+    cancellation_token: CancellationToken,
+) -> CarbonResult<()> {
+    let mut cursor = from;
+    let mut stalls = 0u32;
+
+    while cursor < to {
+        if cancellation_token.is_cancelled() {
+            log::info!("hypersync stripe cancelled at slot {cursor}");
+            return Ok(());
+        }
+
+        let (ids, next_slot) = context.matched_ids(cursor, to).await?;
+        if next_slot <= cursor {
+            stalls += 1;
+            if stalls >= MAX_STALLS {
+                return Err(Error::Custom(format!(
+                    "cursor stalled at slot {cursor} after {MAX_STALLS} attempts \
+                     (range beyond the endpoint's queryable tip?)"
+                )));
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            continue;
+        }
+        stalls = 0;
+
+        if !ids.is_empty() {
+            let Bundles {
+                transactions,
+                mut instructions,
+                blocks,
+            } = context.hydrate(cursor, next_slot, &ids).await?;
+            for (key, tx) in &transactions {
+                let rows = instructions.remove(key).unwrap_or_default();
+                let block = blocks.get(&key.0).copied().unwrap_or((None, None));
+                match assemble(tx, rows, block) {
+                    Ok((update, instruction_count)) => {
+                        context.stats.transactions.fetch_add(1, Ordering::Relaxed);
+                        context
+                            .stats
+                            .instructions
+                            .fetch_add(instruction_count, Ordering::Relaxed);
+                        if sender
+                            .send((Update::Transaction(Box::new(update)), id.clone()))
+                            .await
+                            .is_err()
+                        {
+                            log::info!("update channel closed, stopping hypersync stripe");
+                            return Ok(());
+                        }
+                    }
+                    Err(reason) => {
+                        // Skip loudly: a malformed transaction should never
+                        // take the pipeline down, but must not vanish
+                        // silently either.
+                        log::warn!(
+                            "skipping transaction at slot {} index {}: {reason}",
+                            key.0,
+                            key.1
+                        );
+                    }
+                }
+            }
+        }
+
+        context.stats.pages.fetch_add(1, Ordering::Relaxed);
+        cursor = next_slot;
+    }
+
+    log::debug!("hypersync stripe finished range {from}..{to}");
+    Ok(())
+}
+
+#[async_trait]
+impl Datasource for HyperSyncDatasource {
+    async fn consume(
+        &self,
+        id: DatasourceId,
+        sender: Sender<(Update, DatasourceId)>,
+        cancellation_token: CancellationToken,
+    ) -> CarbonResult<()> {
+        let context = Arc::new(StripeContext {
+            client: self.client()?,
+            programs: self
+                .programs
+                .iter()
+                .map(|p| HsAddress(p.to_bytes()))
+                .collect(),
+            max_transactions_per_page: self.max_transactions_per_page,
+            stats: Arc::clone(&self.stats),
+        });
+
+        let total = self.to_slot.saturating_sub(self.from_slot);
+        let workers = (self.concurrency.max(1) as u64).min(total.max(1));
+        let stripe = total / workers;
+        let remainder = total % workers;
+
+        let mut handles = Vec::with_capacity(workers as usize);
+        let mut start = self.from_slot;
+        for w in 0..workers {
+            let len = stripe + u64::from(w < remainder);
+            let end = start + len;
+            handles.push(tokio::spawn(run_stripe(
+                Arc::clone(&context),
+                start,
+                end,
+                id.clone(),
+                sender.clone(),
+                cancellation_token.clone(),
+            )));
+            start = end;
+        }
+        drop(sender);
+
+        for handle in handles {
+            handle
+                .await
+                .map_err(|e| Error::Custom(format!("hypersync worker panicked: {e}")))??;
+        }
+
+        log::info!(
+            "hypersync datasource finished range {}..{}",
+            self.from_slot,
+            self.to_slot
+        );
+        Ok(())
+    }
+
+    fn update_types(&self) -> Vec<UpdateType> {
+        vec![UpdateType::Transaction]
+    }
+}
+
+/// Rebuild a `TransactionUpdate` from HyperSync rows. Returns the update and
+/// the number of instruction rows it carries.
+fn assemble(
+    tx: &HsTransaction,
+    mut rows: Vec<InstructionCall>,
+    block: (Option<hypersync_solana_net_types::Hash>, Option<i64>),
+) -> Result<(TransactionUpdate, u64), String> {
+    let slot = tx.slot.ok_or("transaction row missing slot")?;
+    let transaction_index = tx
+        .transaction_index
+        .ok_or("transaction row missing index")?;
+
+    let signatures: Vec<Signature> = tx
+        .signatures
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .map(|s| Signature::from(s.0))
+        .collect();
+    if signatures.is_empty() {
+        return Err("no signatures".into());
+    }
+
+    let static_keys: Vec<Pubkey> = tx
+        .account_keys
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .map(|a| Pubkey::new_from_array(a.0))
+        .collect();
+    if static_keys.is_empty() {
+        return Err("no account keys".into());
+    }
+    let loaded_writable: Vec<Pubkey> = tx
+        .loaded_addresses_writable
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .map(|a| Pubkey::new_from_array(a.0))
+        .collect();
+    let loaded_readonly: Vec<Pubkey> = tx
+        .loaded_addresses_readonly
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .map(|a| Pubkey::new_from_array(a.0))
+        .collect();
+
+    // The resolved key list, in the exact order carbon-core's transformer
+    // rebuilds it: static keys, then ALT writable, then ALT readonly.
+    let mut resolved = static_keys.clone();
+    resolved.extend_from_slice(&loaded_writable);
+    resolved.extend_from_slice(&loaded_readonly);
+    let position_of: HashMap<Pubkey, u8> = resolved
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| *i <= u8::MAX as usize)
+        .map(|(i, k)| (*k, i as u8))
+        .collect();
+
+    rows.sort_by(|a, b| a.instruction_address.cmp(&b.instruction_address));
+
+    let mut top_level: Vec<CompiledInstruction> = Vec::new();
+    let mut inner_groups: BTreeMap<u8, Vec<InnerInstruction>> = BTreeMap::new();
+    let mut instruction_count = 0u64;
+
+    for row in &rows {
+        let path = row
+            .instruction_address
+            .as_deref()
+            .ok_or("instruction row missing address path")?;
+        if path.is_empty() {
+            return Err("empty instruction path".into());
+        }
+        if path.len() > MAX_STACK_DEPTH {
+            return Err(format!("instruction path depth {} exceeds 5", path.len()));
+        }
+        let compiled = compile(row, resolved.len(), &position_of)?;
+        instruction_count += 1;
+        if path.len() == 1 {
+            // The archive stores every executed top-level instruction of a
+            // successful transaction, so positions must come out contiguous.
+            if path[0] as usize != top_level.len() {
+                return Err(format!(
+                    "non-contiguous top-level instructions: got {} expected {}",
+                    path[0],
+                    top_level.len()
+                ));
+            }
+            top_level.push(compiled);
+        } else {
+            let index = u8::try_from(path[0]).map_err(|_| "top-level index over 255")?;
+            inner_groups
+                .entry(index)
+                .or_default()
+                .push(InnerInstruction {
+                    instruction: compiled,
+                    stack_height: Some(path.len() as u32),
+                });
+        }
+    }
+    if top_level.is_empty() {
+        return Err("no top-level instructions".into());
+    }
+
+    let message = VersionedMessage::V0(MessageV0 {
+        header: MessageHeader {
+            num_required_signatures: signatures.len().min(u8::MAX as usize) as u8,
+            // Not recoverable from the archive; see the module docs.
+            num_readonly_signed_accounts: 0,
+            num_readonly_unsigned_accounts: 0,
+        },
+        account_keys: static_keys,
+        recent_blockhash: tx
+            .recent_blockhash
+            .map(|h| Hash::new_from_array(h.0))
+            .unwrap_or_default(),
+        instructions: top_level,
+        // Original table references are not stored; the loaded addresses are
+        // carried in `meta.loaded_addresses`, which is where carbon-core's
+        // transformer reads them from.
+        address_table_lookups: vec![],
+    });
+
+    let meta = TransactionStatusMeta {
+        // Only successful transactions exist in the archive.
+        status: Ok(()),
+        fee: tx.fee.unwrap_or_default(),
+        pre_balances: vec![],
+        post_balances: vec![],
+        inner_instructions: Some(
+            inner_groups
+                .into_iter()
+                .map(|(index, instructions)| InnerInstructions {
+                    index,
+                    instructions,
+                })
+                .collect(),
+        ),
+        log_messages: None,
+        pre_token_balances: None,
+        post_token_balances: None,
+        rewards: None,
+        loaded_addresses: LoadedAddresses {
+            writable: loaded_writable,
+            readonly: loaded_readonly,
+        },
+        return_data: None,
+        compute_units_consumed: tx.compute_units_consumed,
+        cost_units: None,
+    };
+
+    let update = TransactionUpdate {
+        signature: signatures[0],
+        transaction: VersionedTransaction {
+            signatures,
+            message,
+        },
+        meta,
+        is_vote: false,
+        slot,
+        index: Some(transaction_index as u64),
+        block_time: block.1,
+        block_hash: block.0.map(|h| Hash::new_from_array(h.0)),
+    };
+    Ok((update, instruction_count))
+}
+
+/// One instruction row into a `CompiledInstruction`, preferring the stored
+/// index columns and falling back to position lookup by address.
+fn compile(
+    row: &InstructionCall,
+    resolved_len: usize,
+    position_of: &HashMap<Pubkey, u8>,
+) -> Result<CompiledInstruction, String> {
+    let program_id_index = match row.executing_account_index {
+        Some(index) => u8::try_from(index).map_err(|_| "program index over 255")?,
+        None => {
+            let program = row.executing_account.ok_or("missing executing account")?;
+            *position_of
+                .get(&Pubkey::new_from_array(program.0))
+                .ok_or("executing account not in key list")?
+        }
+    };
+    if (program_id_index as usize) >= resolved_len {
+        return Err(format!(
+            "program index {program_id_index} out of bounds ({resolved_len} keys)"
+        ));
+    }
+
+    let accounts: Vec<u8> = match row.account_index_arguments.as_deref() {
+        Some(indices) => indices
+            .iter()
+            .map(|&i| u8::try_from(i).map_err(|_| "account index over 255".to_string()))
+            .collect::<Result<_, _>>()?,
+        None => row
+            .account_arguments
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .map(|a| {
+                position_of
+                    .get(&Pubkey::new_from_array(a.0))
+                    .copied()
+                    .ok_or_else(|| "account argument not in key list".to_string())
+            })
+            .collect::<Result<_, _>>()?,
+    };
+    if let Some(&max) = accounts.iter().max() {
+        if (max as usize) >= resolved_len {
+            return Err(format!(
+                "account index {max} out of bounds ({resolved_len} keys)"
+            ));
+        }
+    }
+
+    Ok(CompiledInstruction {
+        program_id_index,
+        accounts,
+        data: row.data.clone().unwrap_or_default(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, carbon_core::transaction::TransactionMetadata};
+
+    fn addr(tag: u8) -> HsAddress {
+        let mut bytes = [0u8; 32];
+        bytes[0] = tag;
+        HsAddress(bytes)
+    }
+
+    fn row(path: &[u32], program_index: u32, accounts: &[u32], data: &[u8]) -> InstructionCall {
+        InstructionCall {
+            slot: Some(430_000_000),
+            transaction_index: Some(3),
+            instruction_address: Some(path.to_vec()),
+            executing_account: Some(addr(program_index as u8)),
+            executing_account_index: Some(program_index),
+            account_arguments: Some(accounts.iter().map(|&i| addr(i as u8)).collect()),
+            account_index_arguments: Some(accounts.to_vec()),
+            data: Some(data.to_vec()),
+            ..Default::default()
+        }
+    }
+
+    /// Six static keys (tags 0..=5) plus one ALT-writable (6) and one
+    /// ALT-readonly (7), so resolved positions 6 and 7 exercise the lookup
+    /// expansion.
+    fn transaction() -> HsTransaction {
+        HsTransaction {
+            slot: Some(430_000_000),
+            transaction_index: Some(3),
+            signatures: Some(vec![HsSignature([9u8; 64])]),
+            fee_payer: Some(addr(0)),
+            fee: Some(5_000),
+            compute_units_consumed: Some(120_000),
+            account_keys: Some((0..6).map(addr).collect()),
+            loaded_addresses_writable: Some(vec![addr(6)]),
+            loaded_addresses_readonly: Some(vec![addr(7)]),
+            ..Default::default()
+        }
+    }
+
+    /// The load-bearing property: paths we emit survive carbon-core's own
+    /// counter-walk reconstruction byte for byte, including a depth-3 chain
+    /// and an ALT-resolved account index.
+    #[test]
+    fn cpi_paths_round_trip_through_carbon_core() {
+        let paths: Vec<Vec<u32>> = vec![
+            vec![0],
+            vec![1],
+            vec![1, 0],
+            vec![1, 1],
+            vec![1, 1, 0],
+            vec![2],
+        ];
+        let rows: Vec<InstructionCall> = paths
+            .iter()
+            .map(|p| row(p, 5, &[1, 2, 6, 7], &[0xAB, 1, 2]))
+            .collect();
+
+        let (update, count) = assemble(&transaction(), rows, (None, Some(1_234))).unwrap();
+        assert_eq!(count, 6);
+        assert_eq!(update.slot, 430_000_000);
+        assert_eq!(update.index, Some(3));
+        assert_eq!(update.block_time, Some(1_234));
+        assert!(!update.is_vote);
+        assert!(update.meta.status.is_ok());
+
+        let metadata = std::sync::Arc::new(TransactionMetadata::try_from(update.clone()).unwrap());
+        let extracted =
+            carbon_core::transformers::extract_instructions_with_metadata(&metadata, &update)
+                .unwrap();
+
+        let reconstructed: Vec<Vec<u32>> = extracted
+            .iter()
+            .map(|(meta, _)| meta.absolute_path.iter().map(|&b| u32::from(b)).collect())
+            .collect();
+        assert_eq!(reconstructed, paths);
+
+        // Stack heights equal path depth, and the ALT accounts resolved to
+        // the positions carbon-core's key concatenation produces.
+        for ((meta, instruction), path) in extracted.iter().zip(&paths) {
+            assert_eq!(meta.stack_height as usize, path.len());
+            assert_eq!(instruction.accounts.len(), 4);
+            assert_eq!(
+                instruction.accounts[2].pubkey,
+                Pubkey::new_from_array({
+                    let mut b = [0u8; 32];
+                    b[0] = 6;
+                    b
+                })
+            );
+        }
+    }
+
+    /// With the index columns absent, compilation falls back to resolving
+    /// positions from the addresses themselves.
+    #[test]
+    fn compile_falls_back_to_address_lookup() {
+        let mut fallback_row = row(&[0], 5, &[1, 6], &[7]);
+        fallback_row.executing_account_index = None;
+        fallback_row.account_index_arguments = None;
+
+        let (update, _) = assemble(&transaction(), vec![fallback_row], (None, None)).unwrap();
+        let compiled = &update.transaction.message.instructions()[0];
+        assert_eq!(compiled.program_id_index, 5);
+        assert_eq!(compiled.accounts, vec![1, 6]);
+    }
+
+    /// Malformed inputs are rejected rather than panicking: a gap in the
+    /// top-level sequence and a path deeper than Solana's stack limit.
+    #[test]
+    fn malformed_transactions_are_skipped_loudly() {
+        let gap = vec![row(&[0], 5, &[1], &[1]), row(&[2], 5, &[1], &[1])];
+        assert!(assemble(&transaction(), gap, (None, None))
+            .unwrap_err()
+            .contains("non-contiguous"));
+
+        let deep = vec![
+            row(&[0], 5, &[1], &[1]),
+            row(&[0, 0, 0, 0, 0, 0], 5, &[1], &[1]),
+        ];
+        assert!(assemble(&transaction(), deep, (None, None))
+            .unwrap_err()
+            .contains("exceeds"));
+    }
+}

--- a/datasources/hypersync-datasource/src/lib.rs
+++ b/datasources/hypersync-datasource/src/lib.rs
@@ -32,11 +32,12 @@
 //!
 //! # Fidelity limits, stated plainly
 //!
-//! - **History window.** The public endpoint serves roughly the last five
-//!   months (floor around slot 403,000,000 as of August 2026). Below the
-//!   floor, compose with `carbon-jetstreamer-datasource`, which reaches
-//!   genesis but lags the head by about two epochs; this datasource covers
-//!   exactly the window Jetstreamer cannot.
+//! - **History window.** The public endpoint's historical depth is a moving
+//!   floor: Envio is actively growing the backfill based on user demand, so
+//!   check the endpoint for current coverage. Below the floor, compose with
+//!   `carbon-jetstreamer-datasource`, which reaches back to genesis but lags
+//!   the head by about two epochs; this datasource serves the recent window
+//!   Jetstreamer cannot.
 //! - **Failed transactions are not served.** The archive stores no
 //!   instruction rows for them, so this datasource only emits successful
 //!   transactions. (`carbon-rpc-block-crawler-datasource` also skips failed


### PR DESCRIPTION
Carbon's `Datasource` trait made this a one-crate integration, so we built it: a bounded historical backfill source over [HyperSync](https://docs.envio.dev/docs/HyperSync/overview), Envio's columnar Solana archive, with the program filter pushed server-side. Only matched transactions cross the network.

**How it works.** Two-pass fetch per page: filter `instruction_calls` by program, then hydrate the matched transaction ids, so pipelines see complete transactions. Inner instructions are regrouped from the archive's exact CPI paths (`stack_height = path.len()`), and the included test round-trips assembled transactions through carbon-core's `extract_instructions_with_metadata` to prove `absolute_path` values reproduce exactly. A `concurrency` knob stripes the slot range, like Jetstreamer's `threads`.

**Numbers** (same pipeline, same decoder, identical slot ranges; runnable harness on our fork: [`hypersync-bench` branch, `examples/hypersync-backfill`](https://github.com/enviodev/carbon/tree/hypersync-bench/examples/hypersync-backfill)):

| Source | Slots/s |
|---|---|
| this crate, 10 workers (default) | ~30 |
| carbon-rpc-block-crawler, paid RPC, concurrency 32 | 4.8 |
| carbon-rpc-block-crawler, public RPC | 1.1 |

Note: this test was run from a personal laptop over a simple home internet network connection. I'm sure many factors could be improved on line speed and location to speed this up. 

Decoded output is **identical** to the block crawler over the same ranges for both `carbon-pumpfun-decoder` (167 txs / 352 instructions) and `carbon-jupiter-swap-decoder` (85 / 225), every per-variant count equal, CPI events included.

**Limits, stated upfront:** the public endpoint needs a bearer token (free tier exists), and its historical depth is a moving floor - Envio is actively growing the backfill based on user demand, so check the endpoint for current coverage; only successful transactions exist in the archive (matching the block crawler's skip-failed behaviour); the message header is synthesized, so `AccountMeta` flags are approximate (no decoder in this repo reads them). Full list in the crate docs. For genesis-deep history this composes with `carbon-jetstreamer-datasource`, which reaches back to genesis but lags the head by about two epochs - a window this crate serves.

One disclosure: the dependency tree pulls arrow 57 (MSRV 1.85, above the workspace's declared 1.82); the crate declares `rust-version = "1.85"`. CI's stable toolchain is unaffected.

Three questions for you rather than assumptions:

1. Are you open to third-party datasource crates in-tree, or would you rather we publish and maintain this externally? Genuinely fine either way - we will maintain it wherever it lives, and can take a CODEOWNERS entry if in-tree.
2. Is the `carbon-` crate name prefix yours to bless? We will not publish under it without a nod.
3. Want a runnable example (`examples/hypersync-backfill`) as a follow-up PR? We kept this one minimal on purpose.

