### PR TITLE
fix(yellowstone): keep filters on the ping resubscribe

### DIFF
--- a/datasources/yellowstone-grpc-datasource/src/lib.rs
+++ b/datasources/yellowstone-grpc-datasource/src/lib.rs
@@ -409,10 +409,11 @@ impl Datasource for YellowstoneGrpcGeyserClient {
                                             }
 
                                             Some(UpdateOneof::Ping(_)) => {
+                                                // Sink replays the last request on reconnect.
                                                 match subscribe_tx
                                                     .send(SubscribeRequest {
                                                         ping: Some(SubscribeRequestPing { id: 1 }),
-                                                        ..Default::default()
+                                                        ..subscribe_request.clone()
                                                     })
                                                     .await {
                                                         Ok(()) => (),


### PR DESCRIPTION
## What

The ping reply sent from the Yellowstone datasource now spreads the original `subscribe_request` instead of `Default::default()`.

## Why

The ping branch built its `SubscribeRequest` from `Default::default()`, so the only populated field was the ping id. The gRPC sink treats the most recent request it received as the subscription state and replays it when the stream reconnects. After the first ping, that remembered state has empty `accounts`, `transactions` and `blocks` filters, so the reconnect at `lib.rs:456` resubscribes filterless and the datasource goes silent instead of resuming.

## How

`..subscribe_request.clone()` in place of `..Default::default()`, so the ping carries the filters the caller configured and the remembered state stays correct.

No API change, no behavior change on the happy path: a ping that already carried the filters is answered the same way by the server.

## Testing

- `cargo check -p carbon-yellowstone-grpc-datasource`
- `cargo clippy -p carbon-yellowstone-grpc-datasource --all-targets -- -D warnings`
- `cargo fmt -p carbon-yellowstone-grpc-datasource -- --check`