### PR TITLE
feat(yellowstone): let callers opt into client-side reconnect

### DIFF
--- a/datasources/yellowstone-grpc-datasource/src/lib.rs
+++ b/datasources/yellowstone-grpc-datasource/src/lib.rs
@@ -17,7 +17,9 @@ use {
     std::{collections::HashMap, convert::TryFrom, sync::LazyLock, time::Duration},
     tokio::sync::{mpsc, mpsc::Sender},
     tokio_util::sync::CancellationToken,
-    yellowstone_grpc_client::{GeyserGrpcBuilder, GeyserGrpcBuilderResult, GeyserGrpcClient},
+    yellowstone_grpc_client::{
+        GeyserGrpcBuilder, GeyserGrpcBuilderResult, GeyserGrpcClient, ReconnectConfig,
+    },
     yellowstone_grpc_proto::{
         geyser::{
             subscribe_update::UpdateOneof, CommitmentLevel, SubscribeRequest,
@@ -128,6 +130,9 @@ pub struct YellowstoneGrpcClientConfig {
     pub max_decoding_message_size: Option<usize>,
     pub tls_config: Option<ClientTlsConfig>,
     pub tcp_nodelay: Option<bool>,
+    /// When set, the client reconnects and replays inside the stream instead of
+    /// surfacing the disconnect. Off by default.
+    pub reconnect: Option<ReconnectConfig>,
 }
 
 impl Default for YellowstoneGrpcClientConfig {
@@ -139,6 +144,7 @@ impl Default for YellowstoneGrpcClientConfig {
             max_decoding_message_size: None,
             tls_config: None,
             tcp_nodelay: None,
+            reconnect: None,
         }
     }
 }
@@ -195,6 +201,14 @@ impl YellowstoneGrpcClientConfig {
             max_decoding_message_size,
             tls_config,
             tcp_nodelay,
+            reconnect: None,
+        }
+    }
+
+    pub fn with_reconnect(self, reconnect: ReconnectConfig) -> Self {
+        YellowstoneGrpcClientConfig {
+            reconnect: Some(reconnect),
+            ..self
         }
     }
 
@@ -222,6 +236,10 @@ impl YellowstoneGrpcClientConfig {
 
         if let Some(val) = self.tcp_nodelay {
             builder = builder.tcp_nodelay(val);
+        }
+
+        if let Some(reconnect) = self.reconnect.clone() {
+            builder = builder.set_reconnect_config(reconnect);
         }
         Ok(builder)
     }


### PR DESCRIPTION
## What

Exposes `yellowstone-grpc-client`'s in-stream reconnect through `YellowstoneGrpcClientConfig`:

- `reconnect: Option<ReconnectConfig>` field
- `with_reconnect(ReconnectConfig)` builder method
- `builder.set_reconnect_config(..)` wired into `geyser_config_builder`

## Why

`yellowstone-grpc-client` 13.5 (already the pinned version) can reconnect and replay missed slots inside the stream via `GeyserGrpcBuilder::set_reconnect_config`, with `ReconnectionPolicy::RecoverMissedData` or `SkipMissedData`. The datasource had no way to reach it, so every consumer got only the outer resubscribe loop, which drops whatever the gap contained. Callers that need gap recovery had to fork the datasource to get at the builder.

The two mechanisms compose rather than conflict: the client handles breaks it can recover from, and the existing `RECONNECT_INITIAL_DELAY_MS` loop still covers subscribe failures the client surfaces.

## How

`None` by default, so behavior is unchanged unless a caller opts in. All in-tree constructors (`::default()`, `::new(..)`) keep their current signatures and set `reconnect: None`.

```rust
let config = YellowstoneGrpcClientConfig::default()
    .with_reconnect(ReconnectConfig::default());
```

## Breaking changes

`YellowstoneGrpcClientConfig` gains a public field, so out-of-tree code that builds it with a struct literal rather than `default()`/`new()` needs `reconnect: None` added. `const fn new` keeps its existing parameter list. Happy to add `#[non_exhaustive]` instead if you'd prefer to close that off.

## Testing

- `cargo check -p carbon-yellowstone-grpc-datasource`
- `cargo check -p yellowstone-grpc-carbon-example -p postgres-graphql-carbon-example` (both in-tree callers)
- `cargo clippy -p carbon-yellowstone-grpc-datasource --all-targets -- -D warnings`
- `cargo fmt -p carbon-yellowstone-grpc-datasource -- --check`

Not exercised against a live endpoint with a forced disconnect; the reconnect path itself is the client's.

## Related

Independent of #588 (ping resubscribe filters), though that fix matters more once reconnect is enabled.