### PR TITLE
chore(release): prepare Carbon 2.0.0

### DIFF
--- a/.github/workflows/check-typescript.yml
+++ b/.github/workflows/check-typescript.yml
@@ -3,7 +3,7 @@ name: TypeScript Packages Check
 on:
   push:
     branches:
-      - master
+      - main
       - ci
   pull_request:
 
@@ -23,7 +23,7 @@ jobs:
       
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20.18.0'
           cache: 'pnpm'
       
       - run: pnpm install --frozen-lockfile
@@ -31,5 +31,3 @@ jobs:
       - run: pnpm test
       - run: pnpm format:check
       - run: pnpm type-check
-
-

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,7 +3,7 @@ name: Cargo Check
 on:
   push:
     branches:
-      - master
+      - main
       - ci
   pull_request:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,95 @@
+# Changelog
+
+## [2.0.0] - 2026-09-04
+
+Carbon 2.0 is the Agave 4 compatibility release. It upgrades the supported Solana dependency cohort, adds end-to-end Transaction V1 handling, and standardizes account-closure delivery without introducing the larger datasource and pipeline redesign planned for Carbon 3.
+
+### Highlights
+
+- Upgraded the workspace to the Agave 4.2-compatible Solana crates and Rust 1.96.1.
+- Added Transaction V1 conversion and instruction traversal, including runtime inner instructions and V1 account metadata.
+- Added strict Yellowstone protobuf conversion for legacy, V0, and V1 transactions.
+- Classified zero-lamport account updates as `Update::AccountDeletion` consistently while preserving the final `Account` state.
+- Added an optional starting slot to Helius LaserStream and opt-in tonic client reconnection to Yellowstone.
+- Added native Codama event rendering, event-CPI discriminator exports, encoded discriminator handling, and base58 instruction-metadata serialization.
+- Hardened instruction handling for short log events and invalid CPI stack heights, and sanitized exported Prometheus metric names.
+- Updated generated projects from `@sevenlabs-hq/carbon-cli` and `@sevenlabs-hq/carbon-codama-renderer` 0.13 to depend on Carbon 2 crates.
+- Corrected the CLI package's ESM and CommonJS export paths.
+- Made the CLI reject GraphQL scaffolds without the Postgres storage layer they require.
+- Fixed template lookup through the renderer's CommonJS entry point.
+- Raised the npm packages' runtime requirement to Node.js 20.18.0.
+
+### Migration from Carbon 1
+
+#### Toolchain and dependencies
+
+Carbon 2 requires Rust 1.96.1. The companion 0.13 CLI, renderer, and version-registry packages require Node.js 20.18.0 or newer. Update every directly declared Carbon crate to `2.0.0` and keep direct Solana dependencies compatible with the Agave 4.2 cohort. Do not mix Carbon 2 with Carbon 1 datasource or decoder crates in one dependency graph.
+
+If Carbon types appear in your public API, update imports and fix type mismatches after resolving the new Solana crates. A single version of each Solana type crate should resolve in the final graph.
+
+#### Transaction source configuration
+
+Caller-owned RPC block configurations must opt into Transaction V1 and request a binary transaction encoding. Carbon cannot reconstruct the original transaction from `Json` or `JsonParsed` payloads.
+
+```rust
+RpcBlockSubscribeConfig {
+    encoding: Some(UiTransactionEncoding::Base64),
+    transaction_details: Some(TransactionDetails::Full),
+    max_supported_transaction_version: Some(1),
+    ..RpcBlockSubscribeConfig::default()
+}
+```
+
+Use the equivalent fields on `RpcBlockConfig` when constructing `RpcBlockCrawler`. Carbon's RPC transaction crawler and Helius GTFA datasource set V1 and Base64 internally.
+
+For Helius Atlas transaction subscriptions, override the SDK's JSON-parsed default and keep V1 enabled:
+
+```rust
+TransactionSubscribeOptions {
+    encoding: Some(UiEnhancedTransactionEncoding::Base64),
+    max_supported_transaction_version: Some(1),
+    ..TransactionSubscribeOptions::default()
+}
+```
+
+#### Account deletions
+
+`AccountDeletion` now contains the source's final `account: Account`. Custom datasources should construct an `AccountUpdate` and call `into_update()` so every zero-lamport account is normalized at the same boundary.
+
+The former `account_deletions_tracked` constructor argument and fields were removed. Remove that argument when constructing:
+
+- `HeliusWebsocket`
+- `LaserStreamGeyserClient`
+- `YellowstoneGrpcGeyserClient`
+- `StreamMessageClient`
+
+If you construct `AccountDeletion` directly, provide its new `account` field.
+
+#### Datasource configuration changes
+
+- `LaserStreamClientConfig::new` has a new trailing `from_slot: Option<u64>` argument. Pass `None` to preserve the previous starting behavior, or use `LaserStreamClientConfig::default()` and set the field.
+- Yellowstone tonic client reconnection is disabled by default. Opt in with `YellowstoneGrpcClientConfig::with_reconnect(ReconnectConfig)` when the upstream supports replay appropriate for your pipeline.
+
+#### SPL Token account helpers
+
+The `Mint::decode`, `Multisig::decode`, and `Token::decode` convenience methods in `carbon-token-program-decoder` were removed. Direct callers should unpack with `solana_program_pack::Pack` and convert the result:
+
+```rust
+let token = spl_token_interface::state::Account::unpack(data)
+    .ok()
+    .map(carbon_token_program_decoder::accounts::token::Token::from);
+```
+
+Normal decoding through `TokenProgramDecoder` requires no special migration.
+
+### Carbon 2 datasource set
+
+The Carbon 2 publication contains these twelve datasource crates:
+
+- Helius Atlas WS, GPA V2, GTFA, and LaserStream
+- RPC block crawler, block subscribe, GPA, program subscribe, and transaction crawler
+- Stream message
+- Validator snapshot
+- Yellowstone gRPC
+
+`carbon-jito-shredstream-grpc-datasource` and `carbon-jetstreamer-datasource` are not published on the 2.0 line. Jito Shredstream does not yet support Transaction V1, while Jetstreamer does not yet support the Solana v4 stack. Existing versions remain available, but they must not be selected as Carbon 2 dependencies.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,9 +86,14 @@ Update producers grouped by source — each crate ships its own README with setu
 
 - **Solana RPC**: `carbon-rpc-block-subscribe-datasource`, `carbon-rpc-program-subscribe-datasource`, `carbon-rpc-transaction-crawler-datasource`, `carbon-rpc-block-crawler-datasource`, `carbon-rpc-gpa-datasource`
 - **Helius**: `carbon-helius-atlas-ws-datasource`, `carbon-helius-laserstream-datasource`, `carbon-helius-gpa-v2-datasource`, `carbon-helius-gtfa-datasource`
-- **Geyser gRPC**: `carbon-yellowstone-grpc-datasource`, `carbon-jito-shredstream-grpc-datasource`
-- **Historical / archive**: `carbon-validator-snapshot-datasource`, `carbon-jetstreamer-datasource`
+- **Geyser gRPC**: `carbon-yellowstone-grpc-datasource`
+- **Historical / archive**: `carbon-validator-snapshot-datasource`
 - **Adapter**: `carbon-stream-message-datasource`
+
+`carbon-jito-shredstream-grpc-datasource` and `carbon-jetstreamer-datasource`
+remain on the Carbon 1 / Solana 3 line and are excluded from the Carbon 2
+workspace. Jito Shredstream does not yet support Transaction V1; Jetstreamer
+does not yet support the Solana v4 stack.
 
 ### Decoders (`decoders/`)
 
@@ -109,12 +114,12 @@ Program-specific decoders for popular Solana programs:
 
 Standalone, runnable indexers — one crate per indexing pattern:
 
-- **`yellowstone-grpc`**: Real-time pipeline (Yellowstone gRPC, with LaserStream and Jito Shredstream variants)
+- **`yellowstone-grpc`**: Real-time pipeline (Yellowstone gRPC, with a LaserStream variant)
 - **`block-subscribe-rpc`**: Real-time pipeline over public Solana RPC
 - **`gpa-rpc`**: Loading current program state via `getProgramAccounts`
 - **`transaction-crawler-rpc`**: Per-program transaction history
 - **`snapshot-validator`**: Loading state from a validator snapshot file
-- **`jetstreamer`**: Bounded-range historical backfill from an archive
+- **`jetstreamer`**: Legacy Carbon 1 bounded-range archive example (excluded from the Carbon 2 workspace)
 - **`versioned-decoders`**: Routing across program upgrades with breaking IDL changes
 - **`postgres-graphql`**: Persisting decoded data to Postgres with a GraphQL query layer
 - **`custom-datasource`**: Reference for implementing your own `Datasource`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "block-subscribe-rpc-carbon-example"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "carbon-core",
  "carbon-log-metrics",
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-address-lookup-table-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -1363,7 +1363,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-associated-token-account-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -1381,7 +1381,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-bonkswap-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -1399,7 +1399,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-boop-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -1417,7 +1417,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-bubblegum-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -1435,7 +1435,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-circle-message-transmitter-v2-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-circle-token-messenger-v2-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -1471,7 +1471,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-core"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1513,7 +1513,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-dflow-aggregator-v4-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -1532,7 +1532,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-drift-v2-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -1551,7 +1551,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-fluxbeam-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-gavel-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-heaven-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-helius-atlas-ws-datasource"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -1629,7 +1629,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-helius-gpa-v2-datasource"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1647,7 +1647,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-helius-gtfa-datasource"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "carbon-core",
@@ -1665,7 +1665,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-helius-laserstream-datasource"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "carbon-core",
@@ -1683,7 +1683,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-jupiter-dca-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -1701,7 +1701,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-jupiter-lend-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -1719,7 +1719,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-jupiter-limit-order-2-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -1737,7 +1737,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-jupiter-limit-order-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-jupiter-perpetuals-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-jupiter-swap-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -1792,7 +1792,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-kamino-farms-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -1811,7 +1811,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-kamino-lending-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -1830,7 +1830,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-kamino-limit-order-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -1849,7 +1849,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-kamino-vault-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-lifinity-amm-v2-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -1886,7 +1886,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-log-metrics"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "carbon-core",
  "log",
@@ -1896,11 +1896,11 @@ dependencies = [
 
 [[package]]
 name = "carbon-macros"
-version = "1.0.0"
+version = "2.0.0"
 
 [[package]]
 name = "carbon-marginfi-v2-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -1919,7 +1919,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-marinade-finance-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-memo-program-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -1955,7 +1955,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-meteora-damm-v2-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -1974,7 +1974,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-meteora-dbc-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-meteora-dlmm-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2012,7 +2012,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-meteora-pools-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2031,7 +2031,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-meteora-vault-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-moonshot-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-mpl-core-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2085,7 +2085,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-mpl-token-metadata-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2103,7 +2103,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-name-service-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2121,7 +2121,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-okx-dex-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2140,7 +2140,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-onchain-labs-dex-v2-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2159,7 +2159,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-openbook-v2-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-orca-whirlpool-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2197,7 +2197,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-pancake-swap-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2216,7 +2216,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-phoenix-v1-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2234,7 +2234,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-proc-macros"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "quote",
  "serde",
@@ -2243,7 +2243,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-prometheus-metrics"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "axum",
  "carbon-core",
@@ -2255,7 +2255,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-pump-fees-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2274,7 +2274,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-pump-swap-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2292,7 +2292,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-pumpfun-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2310,7 +2310,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-raydium-amm-v4-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2329,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-raydium-clmm-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-raydium-cpmm-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-raydium-launchpad-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2386,7 +2386,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-raydium-liquidity-locking-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2404,7 +2404,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-raydium-stable-swap-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2422,7 +2422,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-rpc-block-crawler-datasource"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2439,7 +2439,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-rpc-block-subscribe-datasource"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "carbon-core",
@@ -2454,7 +2454,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-rpc-gpa-datasource"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "carbon-core",
@@ -2470,7 +2470,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-rpc-program-subscribe-datasource"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "carbon-core",
@@ -2485,7 +2485,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-rpc-transaction-crawler-datasource"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2503,7 +2503,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-sharky-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-simple-dex-decoder-v1"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "borsh",
  "carbon-core",
@@ -2533,7 +2533,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-simple-dex-decoder-v2"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "borsh",
  "carbon-core",
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-solayer-restaking-program-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2563,7 +2563,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-stabble-stable-swap-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2581,7 +2581,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-stabble-weighted-swap-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2599,7 +2599,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-stake-program-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-stream-message-datasource"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "carbon-core",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-swig-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2646,7 +2646,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-system-program-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2664,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-test-utils"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2681,7 +2681,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-token-2022-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-token-program-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-validator-snapshot-datasource"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "agave-snapshots",
  "async-trait",
@@ -2745,7 +2745,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-vertigo-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2763,7 +2763,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-virtuals-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2781,7 +2781,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-wavebreak-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-yellowstone-grpc-datasource"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "carbon-core",
@@ -2818,7 +2818,7 @@ dependencies = [
 
 [[package]]
 name = "carbon-zeta-decoder"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -3316,7 +3316,7 @@ dependencies = [
 
 [[package]]
 name = "custom-datasource-carbon-example"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "carbon-core",
@@ -4175,7 +4175,7 @@ dependencies = [
 
 [[package]]
 name = "gpa-rpc-carbon-example"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "carbon-core",
  "carbon-helius-gpa-v2-datasource",
@@ -5968,7 +5968,7 @@ dependencies = [
 
 [[package]]
 name = "postgres-graphql-carbon-example"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "axum",
  "bs58",
@@ -7375,7 +7375,7 @@ dependencies = [
 
 [[package]]
 name = "snapshot-validator-carbon-example"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "carbon-core",
  "carbon-log-metrics",
@@ -11726,7 +11726,7 @@ dependencies = [
 
 [[package]]
 name = "transaction-crawler-rpc-carbon-example"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "carbon-core",
  "carbon-helius-gtfa-datasource",
@@ -11935,7 +11935,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "versioned-decoders-carbon-example"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "carbon-core",
@@ -12551,7 +12551,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-carbon-example"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "carbon-core",
  "carbon-helius-laserstream-datasource",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 
 [workspace.package]
 rust-version = "1.96.1"
-version = "1.0.0"
+version = "2.0.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/sevenlabs-hq/carbon"
@@ -19,98 +19,99 @@ repository = "https://github.com/sevenlabs-hq/carbon"
 [workspace.dependencies]
 
 # main
-carbon-core = { path = "crates/core", version = "1.0.0" }
-carbon-macros = { path = "crates/macros", version = "1.0.0" }
-carbon-proc-macros = { path = "crates/proc-macros", version = "1.0.0" }
-carbon-test-utils = { path = "crates/test-utils", version = "1.0.0" }
+carbon-core = { path = "crates/core", version = "2.0.0" }
+carbon-macros = { path = "crates/macros", version = "2.0.0" }
+carbon-proc-macros = { path = "crates/proc-macros", version = "2.0.0" }
+carbon-test-utils = { path = "crates/test-utils", version = "2.0.0" }
 
 # metrics
-carbon-log-metrics = { path = "metrics/log-metrics", version = "1.0.0" }
-carbon-prometheus-metrics = { path = "metrics/prometheus-metrics", version = "1.0.0" }
+carbon-log-metrics = { path = "metrics/log-metrics", version = "2.0.0" }
+carbon-prometheus-metrics = { path = "metrics/prometheus-metrics", version = "2.0.0" }
 
 # vendor
 carbon-jito-protos = { path = "misc/jito-protos", version = "0.2.4" }
 
 # datasources
-carbon-helius-atlas-ws-datasource = { path = "datasources/helius-atlas-ws-datasource", version = "1.0.0" }
-carbon-helius-gpa-v2-datasource = { path = "datasources/helius-gpa-v2-datasource", version = "1.0.0" }
-carbon-helius-gtfa-datasource = { path = "datasources/helius-gtfa-datasource", version = "1.0.0" }
-carbon-helius-laserstream-datasource = { path = "datasources/helius-laserstream-datasource", version = "1.0.0" }
+carbon-helius-atlas-ws-datasource = { path = "datasources/helius-atlas-ws-datasource", version = "2.0.0" }
+carbon-helius-gpa-v2-datasource = { path = "datasources/helius-gpa-v2-datasource", version = "2.0.0" }
+carbon-helius-gtfa-datasource = { path = "datasources/helius-gtfa-datasource", version = "2.0.0" }
+carbon-helius-laserstream-datasource = { path = "datasources/helius-laserstream-datasource", version = "2.0.0" }
+# Legacy providers remain on Carbon 1.x until they migrate to the Solana v4 stack.
 carbon-jetstreamer-datasource = { path = "datasources/jetstreamer-datasource", version = "1.0.0" }
 carbon-jito-shredstream-grpc-datasource = { path = "datasources/jito-shredstream-grpc-datasource", version = "1.0.0" }
-carbon-rpc-block-crawler-datasource = { path = "datasources/rpc-block-crawler-datasource", version = "1.0.0" }
-carbon-rpc-block-subscribe-datasource = { path = "datasources/rpc-block-subscribe-datasource", version = "1.0.0" }
-carbon-rpc-gpa-datasource = { path = "datasources/rpc-gpa-datasource", version = "1.0.0" }
-carbon-rpc-program-subscribe-datasource = { path = "datasources/rpc-program-subscribe-datasource", version = "1.0.0" }
-carbon-rpc-transaction-crawler-datasource = { path = "datasources/rpc-transaction-crawler-datasource", version = "1.0.0" }
-carbon-stream-message-datasource = { path = "datasources/stream-message-datasource", version = "1.0.0" }
-carbon-validator-snapshot-datasource = { path = "datasources/validator-snapshot-datasource", version = "1.0.0" }
-carbon-yellowstone-grpc-datasource = { path = "datasources/yellowstone-grpc-datasource", version = "1.0.0" }
+carbon-rpc-block-crawler-datasource = { path = "datasources/rpc-block-crawler-datasource", version = "2.0.0" }
+carbon-rpc-block-subscribe-datasource = { path = "datasources/rpc-block-subscribe-datasource", version = "2.0.0" }
+carbon-rpc-gpa-datasource = { path = "datasources/rpc-gpa-datasource", version = "2.0.0" }
+carbon-rpc-program-subscribe-datasource = { path = "datasources/rpc-program-subscribe-datasource", version = "2.0.0" }
+carbon-rpc-transaction-crawler-datasource = { path = "datasources/rpc-transaction-crawler-datasource", version = "2.0.0" }
+carbon-stream-message-datasource = { path = "datasources/stream-message-datasource", version = "2.0.0" }
+carbon-validator-snapshot-datasource = { path = "datasources/validator-snapshot-datasource", version = "2.0.0" }
+carbon-yellowstone-grpc-datasource = { path = "datasources/yellowstone-grpc-datasource", version = "2.0.0" }
 
 # decoders
-carbon-address-lookup-table-decoder = { path = "decoders/address-lookup-table-decoder", version = "1.0.0" }
-carbon-associated-token-account-decoder = { path = "decoders/associated-token-account-decoder", version = "1.0.0" }
-carbon-bonkswap-decoder = { path = "decoders/bonkswap-decoder", version = "1.0.0" }
-carbon-boop-decoder = { path = "decoders/boop-decoder", version = "1.0.0" }
-carbon-bubblegum-decoder = { path = "decoders/bubblegum-decoder", version = "1.0.0" }
-carbon-circle-message-transmitter-v2-decoder = { path = "decoders/circle-message-transmitter-v2-decoder", version = "1.0.0" }
-carbon-circle-token-messenger-v2-decoder = { path = "decoders/circle-token-messenger-v2-decoder", version = "1.0.0" }
-carbon-dflow-aggregator-v4-decoder = { path = "decoders/dflow-aggregator-v4-decoder", version = "1.0.0" }
-carbon-drift-v2-decoder = { path = "decoders/drift-v2-decoder", version = "1.0.0" }
-carbon-fluxbeam-decoder = { path = "decoders/fluxbeam-decoder", version = "1.0.0" }
-carbon-gavel-decoder = { path = "decoders/gavel-decoder", version = "1.0.0" }
-carbon-heaven-decoder = { path = "decoders/heaven-decoder", version = "1.0.0" }
-carbon-jupiter-dca-decoder = { path = "decoders/jupiter-dca-decoder", version = "1.0.0" }
-carbon-jupiter-lend-decoder = { path = "decoders/jupiter-lend-decoder", version = "1.0.0" }
-carbon-jupiter-limit-order-2-decoder = { path = "decoders/jupiter-limit-order-2-decoder", version = "1.0.0" }
-carbon-jupiter-limit-order-decoder = { path = "decoders/jupiter-limit-order-decoder", version = "1.0.0" }
-carbon-jupiter-perpetuals-decoder = { path = "decoders/jupiter-perpetuals-decoder", version = "1.0.0" }
-carbon-jupiter-swap-decoder = { path = "decoders/jupiter-swap-decoder", version = "1.0.0" }
-carbon-kamino-farms-decoder = { path = "decoders/kamino-farms-decoder", version = "1.0.0" }
-carbon-kamino-lending-decoder = { path = "decoders/kamino-lending-decoder", version = "1.0.0" }
-carbon-kamino-limit-order-decoder = { path = "decoders/kamino-limit-order-decoder", version = "1.0.0" }
-carbon-kamino-vault-decoder = { path = "decoders/kamino-vault-decoder", version = "1.0.0" }
-carbon-lifinity-amm-v2-decoder = { path = "decoders/lifinity-amm-v2-decoder", version = "1.0.0" }
-carbon-marginfi-v2-decoder = { path = "decoders/marginfi-v2-decoder", version = "1.0.0" }
-carbon-marinade-finance-decoder = { path = "decoders/marinade-finance-decoder", version = "1.0.0" }
-carbon-memo-program-decoder = { path = "decoders/memo-program-decoder", version = "1.0.0" }
-carbon-meteora-damm-v2-decoder = { path = "decoders/meteora-damm-v2-decoder", version = "1.0.0" }
-carbon-meteora-dbc-decoder = { path = "decoders/meteora-dbc-decoder", version = "1.0.0" }
-carbon-meteora-dlmm-decoder = { path = "decoders/meteora-dlmm-decoder", version = "1.0.0" }
-carbon-meteora-pools-decoder = { path = "decoders/meteora-pools-decoder", version = "1.0.0" }
-carbon-meteora-vault-decoder = { path = "decoders/meteora-vault-decoder", version = "1.0.0" }
-carbon-moonshot-decoder = { path = "decoders/moonshot-decoder", version = "1.0.0" }
-carbon-mpl-core-decoder = { path = "decoders/mpl-core-decoder", version = "1.0.0" }
-carbon-mpl-token-metadata-decoder = { path = "decoders/mpl-token-metadata-decoder", version = "1.0.0" }
-carbon-name-service-decoder = { path = "decoders/name-service-decoder", version = "1.0.0" }
-carbon-okx-dex-decoder = { path = "decoders/okx-dex-decoder", version = "1.0.0" }
-carbon-onchain-labs-dex-v2-decoder = { path = "decoders/onchain-labs-dex-v2-decoder", version = "1.0.0" }
-carbon-openbook-v2-decoder = { path = "decoders/openbook-v2-decoder", version = "1.0.0" }
-carbon-orca-whirlpool-decoder = { path = "decoders/orca-whirlpool-decoder", version = "1.0.0" }
-carbon-pancake-swap-decoder = { path = "decoders/pancake-swap-decoder", version = "1.0.0" }
-carbon-phoenix-v1-decoder = { path = "decoders/phoenix-v1-decoder", version = "1.0.0" }
-carbon-pump-fees-decoder = { path = "decoders/pump-fees-decoder", version = "1.0.0" }
-carbon-pump-swap-decoder = { path = "decoders/pump-swap-decoder", version = "1.0.0" }
-carbon-pumpfun-decoder = { path = "decoders/pumpfun-decoder", version = "1.0.0" }
-carbon-raydium-amm-v4-decoder = { path = "decoders/raydium-amm-v4-decoder", version = "1.0.0" }
-carbon-raydium-clmm-decoder = { path = "decoders/raydium-clmm-decoder", version = "1.0.0" }
-carbon-raydium-cpmm-decoder = { path = "decoders/raydium-cpmm-decoder", version = "1.0.0" }
-carbon-raydium-launchpad-decoder = { path = "decoders/raydium-launchpad-decoder", version = "1.0.0" }
-carbon-raydium-liquidity-locking-decoder = { path = "decoders/raydium-liquidity-locking-decoder", version = "1.0.0" }
-carbon-raydium-stable-swap-decoder = { path = "decoders/raydium-stable-swap-decoder", version = "1.0.0" }
-carbon-sharky-decoder = { path = "decoders/sharky-decoder", version = "1.0.0" }
-carbon-solayer-restaking-program-decoder = { path = "decoders/solayer-restaking-program-decoder", version = "1.0.0" }
-carbon-stabble-stable-swap-decoder = { path = "decoders/stabble-stable-swap-decoder", version = "1.0.0" }
-carbon-stabble-weighted-swap-decoder = { path = "decoders/stabble-weighted-swap-decoder", version = "1.0.0" }
-carbon-stake-program-decoder = { path = "decoders/stake-program-decoder", version = "1.0.0" }
-carbon-swig-decoder = { path = "decoders/swig-decoder", version = "1.0.0" }
-carbon-system-program-decoder = { path = "decoders/system-program-decoder", version = "1.0.0" }
-carbon-token-2022-decoder = { path = "decoders/token-2022-decoder", version = "1.0.0" }
-carbon-token-program-decoder = { path = "decoders/token-program-decoder", version = "1.0.0" }
-carbon-vertigo-decoder = { path = "decoders/vertigo-decoder", version = "1.0.0" }
-carbon-virtuals-decoder = { path = "decoders/virtuals-decoder", version = "1.0.0" }
-carbon-wavebreak-decoder = { path = "decoders/wavebreak-decoder", version = "1.0.0" }
-carbon-zeta-decoder = { path = "decoders/zeta-decoder", version = "1.0.0" }
+carbon-address-lookup-table-decoder = { path = "decoders/address-lookup-table-decoder", version = "2.0.0" }
+carbon-associated-token-account-decoder = { path = "decoders/associated-token-account-decoder", version = "2.0.0" }
+carbon-bonkswap-decoder = { path = "decoders/bonkswap-decoder", version = "2.0.0" }
+carbon-boop-decoder = { path = "decoders/boop-decoder", version = "2.0.0" }
+carbon-bubblegum-decoder = { path = "decoders/bubblegum-decoder", version = "2.0.0" }
+carbon-circle-message-transmitter-v2-decoder = { path = "decoders/circle-message-transmitter-v2-decoder", version = "2.0.0" }
+carbon-circle-token-messenger-v2-decoder = { path = "decoders/circle-token-messenger-v2-decoder", version = "2.0.0" }
+carbon-dflow-aggregator-v4-decoder = { path = "decoders/dflow-aggregator-v4-decoder", version = "2.0.0" }
+carbon-drift-v2-decoder = { path = "decoders/drift-v2-decoder", version = "2.0.0" }
+carbon-fluxbeam-decoder = { path = "decoders/fluxbeam-decoder", version = "2.0.0" }
+carbon-gavel-decoder = { path = "decoders/gavel-decoder", version = "2.0.0" }
+carbon-heaven-decoder = { path = "decoders/heaven-decoder", version = "2.0.0" }
+carbon-jupiter-dca-decoder = { path = "decoders/jupiter-dca-decoder", version = "2.0.0" }
+carbon-jupiter-lend-decoder = { path = "decoders/jupiter-lend-decoder", version = "2.0.0" }
+carbon-jupiter-limit-order-2-decoder = { path = "decoders/jupiter-limit-order-2-decoder", version = "2.0.0" }
+carbon-jupiter-limit-order-decoder = { path = "decoders/jupiter-limit-order-decoder", version = "2.0.0" }
+carbon-jupiter-perpetuals-decoder = { path = "decoders/jupiter-perpetuals-decoder", version = "2.0.0" }
+carbon-jupiter-swap-decoder = { path = "decoders/jupiter-swap-decoder", version = "2.0.0" }
+carbon-kamino-farms-decoder = { path = "decoders/kamino-farms-decoder", version = "2.0.0" }
+carbon-kamino-lending-decoder = { path = "decoders/kamino-lending-decoder", version = "2.0.0" }
+carbon-kamino-limit-order-decoder = { path = "decoders/kamino-limit-order-decoder", version = "2.0.0" }
+carbon-kamino-vault-decoder = { path = "decoders/kamino-vault-decoder", version = "2.0.0" }
+carbon-lifinity-amm-v2-decoder = { path = "decoders/lifinity-amm-v2-decoder", version = "2.0.0" }
+carbon-marginfi-v2-decoder = { path = "decoders/marginfi-v2-decoder", version = "2.0.0" }
+carbon-marinade-finance-decoder = { path = "decoders/marinade-finance-decoder", version = "2.0.0" }
+carbon-memo-program-decoder = { path = "decoders/memo-program-decoder", version = "2.0.0" }
+carbon-meteora-damm-v2-decoder = { path = "decoders/meteora-damm-v2-decoder", version = "2.0.0" }
+carbon-meteora-dbc-decoder = { path = "decoders/meteora-dbc-decoder", version = "2.0.0" }
+carbon-meteora-dlmm-decoder = { path = "decoders/meteora-dlmm-decoder", version = "2.0.0" }
+carbon-meteora-pools-decoder = { path = "decoders/meteora-pools-decoder", version = "2.0.0" }
+carbon-meteora-vault-decoder = { path = "decoders/meteora-vault-decoder", version = "2.0.0" }
+carbon-moonshot-decoder = { path = "decoders/moonshot-decoder", version = "2.0.0" }
+carbon-mpl-core-decoder = { path = "decoders/mpl-core-decoder", version = "2.0.0" }
+carbon-mpl-token-metadata-decoder = { path = "decoders/mpl-token-metadata-decoder", version = "2.0.0" }
+carbon-name-service-decoder = { path = "decoders/name-service-decoder", version = "2.0.0" }
+carbon-okx-dex-decoder = { path = "decoders/okx-dex-decoder", version = "2.0.0" }
+carbon-onchain-labs-dex-v2-decoder = { path = "decoders/onchain-labs-dex-v2-decoder", version = "2.0.0" }
+carbon-openbook-v2-decoder = { path = "decoders/openbook-v2-decoder", version = "2.0.0" }
+carbon-orca-whirlpool-decoder = { path = "decoders/orca-whirlpool-decoder", version = "2.0.0" }
+carbon-pancake-swap-decoder = { path = "decoders/pancake-swap-decoder", version = "2.0.0" }
+carbon-phoenix-v1-decoder = { path = "decoders/phoenix-v1-decoder", version = "2.0.0" }
+carbon-pump-fees-decoder = { path = "decoders/pump-fees-decoder", version = "2.0.0" }
+carbon-pump-swap-decoder = { path = "decoders/pump-swap-decoder", version = "2.0.0" }
+carbon-pumpfun-decoder = { path = "decoders/pumpfun-decoder", version = "2.0.0" }
+carbon-raydium-amm-v4-decoder = { path = "decoders/raydium-amm-v4-decoder", version = "2.0.0" }
+carbon-raydium-clmm-decoder = { path = "decoders/raydium-clmm-decoder", version = "2.0.0" }
+carbon-raydium-cpmm-decoder = { path = "decoders/raydium-cpmm-decoder", version = "2.0.0" }
+carbon-raydium-launchpad-decoder = { path = "decoders/raydium-launchpad-decoder", version = "2.0.0" }
+carbon-raydium-liquidity-locking-decoder = { path = "decoders/raydium-liquidity-locking-decoder", version = "2.0.0" }
+carbon-raydium-stable-swap-decoder = { path = "decoders/raydium-stable-swap-decoder", version = "2.0.0" }
+carbon-sharky-decoder = { path = "decoders/sharky-decoder", version = "2.0.0" }
+carbon-solayer-restaking-program-decoder = { path = "decoders/solayer-restaking-program-decoder", version = "2.0.0" }
+carbon-stabble-stable-swap-decoder = { path = "decoders/stabble-stable-swap-decoder", version = "2.0.0" }
+carbon-stabble-weighted-swap-decoder = { path = "decoders/stabble-weighted-swap-decoder", version = "2.0.0" }
+carbon-stake-program-decoder = { path = "decoders/stake-program-decoder", version = "2.0.0" }
+carbon-swig-decoder = { path = "decoders/swig-decoder", version = "2.0.0" }
+carbon-system-program-decoder = { path = "decoders/system-program-decoder", version = "2.0.0" }
+carbon-token-2022-decoder = { path = "decoders/token-2022-decoder", version = "2.0.0" }
+carbon-token-program-decoder = { path = "decoders/token-program-decoder", version = "2.0.0" }
+carbon-vertigo-decoder = { path = "decoders/vertigo-decoder", version = "2.0.0" }
+carbon-virtuals-decoder = { path = "decoders/virtuals-decoder", version = "2.0.0" }
+carbon-wavebreak-decoder = { path = "decoders/wavebreak-decoder", version = "2.0.0" }
+carbon-zeta-decoder = { path = "decoders/zeta-decoder", version = "2.0.0" }
 
 # solana
 agave-snapshots = { version = "=4.2.2", features = ["agave-unstable-api"] }

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ use carbon_core::{error::CarbonResult, pipeline::Pipeline};
 use carbon_log_metrics::LogMetrics;
 use carbon_my_program_decoder::{MyProgramDecoder, PROGRAM_ID};
 use carbon_rpc_block_subscribe_datasource::{Filters, RpcBlockSubscribe};
-use solana_client::rpc_config::RpcBlockSubscribeFilter;
+use solana_client::rpc_config::{RpcBlockSubscribeConfig, RpcBlockSubscribeFilter};
+use solana_transaction_status::{TransactionDetails, UiTransactionEncoding};
 
 #[tokio::main]
 async fn main() -> CarbonResult<()> {
@@ -58,7 +59,12 @@ async fn main() -> CarbonResult<()> {
         "wss://api.mainnet-beta.solana.com".to_string(),
         Filters::new(
             RpcBlockSubscribeFilter::MentionsAccountOrProgram(PROGRAM_ID.to_string()),
-            None,
+            Some(RpcBlockSubscribeConfig {
+                encoding: Some(UiTransactionEncoding::Base64),
+                transaction_details: Some(TransactionDetails::Full),
+                max_supported_transaction_version: Some(1),
+                ..RpcBlockSubscribeConfig::default()
+            }),
         ),
     );
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-core"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Core library for Carbon"
 license = { workspace = true }

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-macros"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Macros for Carbon"
 license = { workspace = true }

--- a/crates/proc-macros/Cargo.toml
+++ b/crates/proc-macros/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-proc-macros"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Procedural macros for Carbon"
 license = { workspace = true }

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-test-utils"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Testing utilities for Carbon"
 license = { workspace = true }

--- a/datasources/helius-atlas-ws-datasource/Cargo.toml
+++ b/datasources/helius-atlas-ws-datasource/Cargo.toml
@@ -2,7 +2,8 @@
 name = "carbon-helius-atlas-ws-datasource"
 description = "Helius Atlas WebSocket Datasource"
 license = { workspace = true }
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 readme = "README.md"
 repository = { workspace = true }

--- a/datasources/helius-gpa-v2-datasource/Cargo.toml
+++ b/datasources/helius-gpa-v2-datasource/Cargo.toml
@@ -2,7 +2,8 @@
 name = "carbon-helius-gpa-v2-datasource"
 description = "Helius gPA V2 Datasource - Fetches program accounts using Helius getProgramAccountsV2 with pagination and changedSinceSlot support"
 license = { workspace = true }
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 readme = "README.md"
 repository = { workspace = true }

--- a/datasources/helius-gtfa-datasource/Cargo.toml
+++ b/datasources/helius-gtfa-datasource/Cargo.toml
@@ -2,7 +2,8 @@
 name = "carbon-helius-gtfa-datasource"
 description = "Helius GTFA Datasource - Fetches transactions for an address using Helius getTransactionsForAddress with advanced filtering, sorting, and pagination"
 license = { workspace = true }
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 readme = "README.md"
 repository = { workspace = true }

--- a/datasources/helius-laserstream-datasource/Cargo.toml
+++ b/datasources/helius-laserstream-datasource/Cargo.toml
@@ -2,7 +2,8 @@
 name = "carbon-helius-laserstream-datasource"
 description = "Helius Laserstream Datasource with automatic reconnection and slot replay"
 license = { workspace = true }
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 readme = "README.md"
 repository = { workspace = true }

--- a/datasources/jetstreamer-datasource/README.md
+++ b/datasources/jetstreamer-datasource/README.md
@@ -1,1 +1,7 @@
 # Carbon Jetstreamer Datasource
+
+> [!NOTE]
+> This datasource remains on Carbon 1 / Solana 3 and is not published in the
+> Carbon 2 release because Jetstreamer does not yet support the Solana v4 stack.
+> The directory is retained as archival source and is not buildable inside the
+> Carbon 2 workspace; use the published 1.x crate from a Carbon 1 application.

--- a/datasources/jito-shredstream-grpc-datasource/README.md
+++ b/datasources/jito-shredstream-grpc-datasource/README.md
@@ -1,5 +1,11 @@
 # Carbon Jito Shredstream gRPC Datasource
 
+> [!NOTE]
+> This datasource remains on Carbon 1 / Solana 3 and is not published in the
+> Carbon 2 release because the source does not yet support Transaction V1.
+> The directory is retained as archival source and is not buildable inside the
+> Carbon 2 workspace; use the published 1.x crate from a Carbon 1 application.
+
 _Shreds are fragments of data used in the Solana blockchain to represent parts of transactions before they are assembled into a full block. When a validator processes transactions, it breaks them down into smaller units called shreds. These shreds are distributed across the network..._ https://docs.jito.wtf/lowlatencytxnfeed/
 
 > [!WARNING]  

--- a/datasources/rpc-block-crawler-datasource/Cargo.toml
+++ b/datasources/rpc-block-crawler-datasource/Cargo.toml
@@ -2,7 +2,8 @@
 name = "carbon-rpc-block-crawler-datasource"
 description = "RPC Block Crawler Datasource"
 license = { workspace = true }
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 readme = "README.md"
 repository = { workspace = true }

--- a/datasources/rpc-block-subscribe-datasource/Cargo.toml
+++ b/datasources/rpc-block-subscribe-datasource/Cargo.toml
@@ -2,7 +2,8 @@
 name = "carbon-rpc-block-subscribe-datasource"
 description = "RPC Block Subscribe Datasource"
 license = { workspace = true }
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 readme = "README.md"
 repository = { workspace = true }

--- a/datasources/rpc-gpa-datasource/Cargo.toml
+++ b/datasources/rpc-gpa-datasource/Cargo.toml
@@ -2,7 +2,8 @@
 name = "carbon-rpc-gpa-datasource"
 description = "RPC gPA Datasource - Fetches all accounts for a program using getProgramAccounts"
 license = { workspace = true }
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 readme = "README.md"
 repository = { workspace = true }

--- a/datasources/rpc-program-subscribe-datasource/Cargo.toml
+++ b/datasources/rpc-program-subscribe-datasource/Cargo.toml
@@ -2,7 +2,8 @@
 name = "carbon-rpc-program-subscribe-datasource"
 description = "RPC Program Subscribe Datasource"
 license = { workspace = true }
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 readme = "README.md"
 repository = { workspace = true }

--- a/datasources/rpc-transaction-crawler-datasource/Cargo.toml
+++ b/datasources/rpc-transaction-crawler-datasource/Cargo.toml
@@ -2,7 +2,8 @@
 name = "carbon-rpc-transaction-crawler-datasource"
 description = "RPC Transaction Crawler Datasource"
 license = { workspace = true }
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 readme = "README.md"
 repository = { workspace = true }

--- a/datasources/stream-message-datasource/Cargo.toml
+++ b/datasources/stream-message-datasource/Cargo.toml
@@ -2,7 +2,8 @@
 name = "carbon-stream-message-datasource"
 description = "Stream Message Datasource"
 license = { workspace = true }
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 readme = "README.md"
 repository = { workspace = true }

--- a/datasources/validator-snapshot-datasource/Cargo.toml
+++ b/datasources/validator-snapshot-datasource/Cargo.toml
@@ -2,7 +2,8 @@
 name = "carbon-validator-snapshot-datasource"
 description = "Carbon Validator Snapshot Datasource - Index accounts from Solana validator snapshots"
 license = { workspace = true }
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 readme = "README.md"
 repository = { workspace = true }

--- a/datasources/yellowstone-grpc-datasource/Cargo.toml
+++ b/datasources/yellowstone-grpc-datasource/Cargo.toml
@@ -2,7 +2,8 @@
 name = "carbon-yellowstone-grpc-datasource"
 description = "Yellowstone gRPC Datasource"
 license = { workspace = true }
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 readme = "README.md"
 repository = { workspace = true }

--- a/decoders/address-lookup-table-decoder/Cargo.toml
+++ b/decoders/address-lookup-table-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-address-lookup-table-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Address lookup table program decoder"
 license = { workspace = true }

--- a/decoders/associated-token-account-decoder/Cargo.toml
+++ b/decoders/associated-token-account-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-associated-token-account-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Associated Token Account program decoder"
 license = { workspace = true }

--- a/decoders/bonkswap-decoder/Cargo.toml
+++ b/decoders/bonkswap-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-bonkswap-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Carbon BonkSwap Decoder"
 license = { workspace = true }

--- a/decoders/boop-decoder/Cargo.toml
+++ b/decoders/boop-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-boop-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Boop program decoder"
 license = { workspace = true }

--- a/decoders/bubblegum-decoder/Cargo.toml
+++ b/decoders/bubblegum-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-bubblegum-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Bubblegum Program Decoder"
 license = { workspace = true }

--- a/decoders/circle-message-transmitter-v2-decoder/Cargo.toml
+++ b/decoders/circle-message-transmitter-v2-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-circle-message-transmitter-v2-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Circle CCTP Message Transmitter V2 Decoder"
 license = { workspace = true }

--- a/decoders/circle-token-messenger-v2-decoder/Cargo.toml
+++ b/decoders/circle-token-messenger-v2-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-circle-token-messenger-v2-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Circle CCTP Token Messenger V2 Decoder"
 license = { workspace = true }

--- a/decoders/dflow-aggregator-v4-decoder/Cargo.toml
+++ b/decoders/dflow-aggregator-v4-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-dflow-aggregator-v4-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Dflow Aggregator V4 Decoder"
 license = { workspace = true }

--- a/decoders/drift-v2-decoder/Cargo.toml
+++ b/decoders/drift-v2-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-drift-v2-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Drift v2 Decoder"
 license = { workspace = true }

--- a/decoders/fluxbeam-decoder/Cargo.toml
+++ b/decoders/fluxbeam-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-fluxbeam-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Fluxbeam Decoder"
 license = { workspace = true }

--- a/decoders/gavel-decoder/Cargo.toml
+++ b/decoders/gavel-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-gavel-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Gavel Pool Decoder"
 license = { workspace = true }

--- a/decoders/heaven-decoder/Cargo.toml
+++ b/decoders/heaven-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-heaven-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Heaven program decoder"
 license = { workspace = true }

--- a/decoders/jupiter-dca-decoder/Cargo.toml
+++ b/decoders/jupiter-dca-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-jupiter-dca-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Jupiter DCA Decoder"
 license = { workspace = true }

--- a/decoders/jupiter-lend-decoder/Cargo.toml
+++ b/decoders/jupiter-lend-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-jupiter-lend-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Jupiter Lend Liquidity Decoder"
 license = { workspace = true }

--- a/decoders/jupiter-limit-order-2-decoder/Cargo.toml
+++ b/decoders/jupiter-limit-order-2-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-jupiter-limit-order-2-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Jupiter Limit Order 2 Decoder"
 license = { workspace = true }

--- a/decoders/jupiter-limit-order-decoder/Cargo.toml
+++ b/decoders/jupiter-limit-order-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-jupiter-limit-order-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Jupiter Limit Order Decoder"
 license = { workspace = true }

--- a/decoders/jupiter-perpetuals-decoder/Cargo.toml
+++ b/decoders/jupiter-perpetuals-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-jupiter-perpetuals-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Jupiter Perpetuals Decoder"
 license = { workspace = true }

--- a/decoders/jupiter-swap-decoder/Cargo.toml
+++ b/decoders/jupiter-swap-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-jupiter-swap-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Jupiter Swap Decoder"
 license = { workspace = true }

--- a/decoders/kamino-farms-decoder/Cargo.toml
+++ b/decoders/kamino-farms-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-kamino-farms-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Kamino Farms Decoder"
 license = { workspace = true }

--- a/decoders/kamino-lending-decoder/Cargo.toml
+++ b/decoders/kamino-lending-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-kamino-lending-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Kamino Lending Decoder"
 license = { workspace = true }

--- a/decoders/kamino-limit-order-decoder/Cargo.toml
+++ b/decoders/kamino-limit-order-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-kamino-limit-order-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Kamino Limit Order Decoder"
 license = { workspace = true }

--- a/decoders/kamino-vault-decoder/Cargo.toml
+++ b/decoders/kamino-vault-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-kamino-vault-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Kamino Vault Decoder"
 license = { workspace = true }

--- a/decoders/lifinity-amm-v2-decoder/Cargo.toml
+++ b/decoders/lifinity-amm-v2-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-lifinity-amm-v2-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Lifinity AMM V2 Decoder"
 license = { workspace = true }

--- a/decoders/marginfi-v2-decoder/Cargo.toml
+++ b/decoders/marginfi-v2-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-marginfi-v2-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "MarginfiV2 Decoder"
 license = { workspace = true }

--- a/decoders/marinade-finance-decoder/Cargo.toml
+++ b/decoders/marinade-finance-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-marinade-finance-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Marinade Finance Decoder"
 license = { workspace = true }

--- a/decoders/memo-program-decoder/Cargo.toml
+++ b/decoders/memo-program-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-memo-program-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Memo Program Decoder"
 license = { workspace = true }

--- a/decoders/meteora-damm-v2-decoder/Cargo.toml
+++ b/decoders/meteora-damm-v2-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-meteora-damm-v2-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Carbon Meteora Damm V2 Decoder"
 license = { workspace = true }

--- a/decoders/meteora-dbc-decoder/Cargo.toml
+++ b/decoders/meteora-dbc-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-meteora-dbc-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Meteora DBC Decoder"
 license = { workspace = true }

--- a/decoders/meteora-dlmm-decoder/Cargo.toml
+++ b/decoders/meteora-dlmm-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-meteora-dlmm-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Meteora DLMM Decoder"
 license = { workspace = true }

--- a/decoders/meteora-pools-decoder/Cargo.toml
+++ b/decoders/meteora-pools-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-meteora-pools-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Meteora Pools Program Decoder"
 license = { workspace = true }

--- a/decoders/meteora-vault-decoder/Cargo.toml
+++ b/decoders/meteora-vault-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-meteora-vault-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Meteora vault program decoder"
 license = { workspace = true }

--- a/decoders/moonshot-decoder/Cargo.toml
+++ b/decoders/moonshot-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-moonshot-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Moonshot Decoder"
 license = { workspace = true }

--- a/decoders/mpl-core-decoder/Cargo.toml
+++ b/decoders/mpl-core-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-mpl-core-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "MPL Core Decoder"
 license = { workspace = true }

--- a/decoders/mpl-token-metadata-decoder/Cargo.toml
+++ b/decoders/mpl-token-metadata-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-mpl-token-metadata-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "MPL Token Metadata Decoder"
 license = { workspace = true }

--- a/decoders/name-service-decoder/Cargo.toml
+++ b/decoders/name-service-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-name-service-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Name Service Decoder"
 license = { workspace = true }

--- a/decoders/okx-dex-decoder/Cargo.toml
+++ b/decoders/okx-dex-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-okx-dex-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "OKX DEX Decoder"
 license = { workspace = true }

--- a/decoders/onchain-labs-dex-v2-decoder/Cargo.toml
+++ b/decoders/onchain-labs-dex-v2-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-onchain-labs-dex-v2-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "OnChain Labs DEX V2 Decoder"
 license = { workspace = true }

--- a/decoders/openbook-v2-decoder/Cargo.toml
+++ b/decoders/openbook-v2-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-openbook-v2-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Openbook V2 Decoder"
 license = { workspace = true }

--- a/decoders/orca-whirlpool-decoder/Cargo.toml
+++ b/decoders/orca-whirlpool-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-orca-whirlpool-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Orca Whirlpool Decoder"
 license = { workspace = true }

--- a/decoders/pancake-swap-decoder/Cargo.toml
+++ b/decoders/pancake-swap-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-pancake-swap-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Carbon PancakeSwap Decoder"
 license = { workspace = true }

--- a/decoders/phoenix-v1-decoder/Cargo.toml
+++ b/decoders/phoenix-v1-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-phoenix-v1-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Phoenix V1 Decoder"
 license = { workspace = true }

--- a/decoders/pump-fees-decoder/Cargo.toml
+++ b/decoders/pump-fees-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-pump-fees-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "PumpFees Decoder"
 license = { workspace = true }

--- a/decoders/pump-swap-decoder/Cargo.toml
+++ b/decoders/pump-swap-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-pump-swap-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "PumpSwap Decoder"
 license = { workspace = true }

--- a/decoders/pumpfun-decoder/Cargo.toml
+++ b/decoders/pumpfun-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-pumpfun-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Pumpfun Decoder"
 license = { workspace = true }

--- a/decoders/raydium-amm-v4-decoder/Cargo.toml
+++ b/decoders/raydium-amm-v4-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-raydium-amm-v4-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Raydium AMM V4 Decoder"
 license = { workspace = true }

--- a/decoders/raydium-clmm-decoder/Cargo.toml
+++ b/decoders/raydium-clmm-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-raydium-clmm-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Raydium CLMM Decoder"
 license = { workspace = true }

--- a/decoders/raydium-cpmm-decoder/Cargo.toml
+++ b/decoders/raydium-cpmm-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-raydium-cpmm-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Raydium CPMM Decoder"
 license = { workspace = true }

--- a/decoders/raydium-launchpad-decoder/Cargo.toml
+++ b/decoders/raydium-launchpad-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-raydium-launchpad-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Raydium Launchpad Decoder"
 license = { workspace = true }

--- a/decoders/raydium-liquidity-locking-decoder/Cargo.toml
+++ b/decoders/raydium-liquidity-locking-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-raydium-liquidity-locking-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Raydium Liquidity Locking Decoder"
 license = { workspace = true }

--- a/decoders/raydium-stable-swap-decoder/Cargo.toml
+++ b/decoders/raydium-stable-swap-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-raydium-stable-swap-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Raydium Stable Swap Decoder"
 license = { workspace = true }

--- a/decoders/sharky-decoder/Cargo.toml
+++ b/decoders/sharky-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-sharky-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Sharky Decoder"
 license = { workspace = true }

--- a/decoders/solayer-restaking-program-decoder/Cargo.toml
+++ b/decoders/solayer-restaking-program-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-solayer-restaking-program-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Solayer Restaking Decoder"
 license = { workspace = true }

--- a/decoders/stabble-stable-swap-decoder/Cargo.toml
+++ b/decoders/stabble-stable-swap-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-stabble-stable-swap-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Stabble Stable Swap decoder"
 license = { workspace = true }

--- a/decoders/stabble-weighted-swap-decoder/Cargo.toml
+++ b/decoders/stabble-weighted-swap-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-stabble-weighted-swap-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Stabble Weighted Swap Decoder"
 license = { workspace = true }

--- a/decoders/stake-program-decoder/Cargo.toml
+++ b/decoders/stake-program-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-stake-program-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Stake Program Decoder"
 license = { workspace = true }

--- a/decoders/swig-decoder/Cargo.toml
+++ b/decoders/swig-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-swig-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Swig Decoder"
 license = { workspace = true }

--- a/decoders/system-program-decoder/Cargo.toml
+++ b/decoders/system-program-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-system-program-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "System Program Decoder"
 license = { workspace = true }

--- a/decoders/token-2022-decoder/Cargo.toml
+++ b/decoders/token-2022-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-token-2022-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Carbon Token 2022 Decoder"
 license = { workspace = true }

--- a/decoders/token-program-decoder/Cargo.toml
+++ b/decoders/token-program-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-token-program-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Token Program Decoder"
 license = { workspace = true }

--- a/decoders/vertigo-decoder/Cargo.toml
+++ b/decoders/vertigo-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-vertigo-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Vertigo DEX Program Decoder"
 license = { workspace = true }

--- a/decoders/virtuals-decoder/Cargo.toml
+++ b/decoders/virtuals-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-virtuals-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Virtuals Program Decoder"
 license = { workspace = true }

--- a/decoders/wavebreak-decoder/Cargo.toml
+++ b/decoders/wavebreak-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-wavebreak-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Wavebreak Program Decoder"
 license = { workspace = true }

--- a/decoders/zeta-decoder/Cargo.toml
+++ b/decoders/zeta-decoder/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-zeta-decoder"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 description = "Zeta Program Decoder"
 license = { workspace = true }

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,27 +6,27 @@ This directory contains standlone Carbon pipelines, each demonstrating a distinc
 
 If you're not sure which one fits, find your use case below:
 
-| What you're building                                         | Start with                                           |
-| ------------------------------------------------------------ | ---------------------------------------------------- |
-| Real-time pipeline (gRPC)                                    | [`yellowstone-grpc`](yellowstone-grpc)               |
-| Real-time pipeline (no Geyser, public RPC)                   | [`block-subscribe-rpc`](block-subscribe-rpc)         |
-| Bounded-range historical backfill via archive                | [`jetstreamer`](jetstreamer)                         |
-| Per-program transaction history backfill                     | [`transaction-crawler-rpc`](transaction-crawler-rpc) |
-| Loading current state via RPC `getProgramAccounts`           | [`gpa-rpc`](gpa-rpc)                                 |
-| Loading state from a validator snapshot file                 | [`snapshot-validator`](snapshot-validator)           |
-| Indexing a program upgraded with a breaking IDL change           | [`versioned-decoders`](versioned-decoders)           |
-| Persisting decoded data to Postgres and serving it via GraphQL | [`postgres-graphql`](postgres-graphql)             |
-| Implementing your own `Datasource`                           | [`custom-datasource`](custom-datasource)             |
+| What you're building                                           | Start with                                           |
+| -------------------------------------------------------------- | ---------------------------------------------------- |
+| Real-time pipeline (gRPC)                                      | [`yellowstone-grpc`](yellowstone-grpc)               |
+| Real-time pipeline (no Geyser, public RPC)                     | [`block-subscribe-rpc`](block-subscribe-rpc)         |
+| Legacy Carbon 1 archive backfill                               | [`jetstreamer`](jetstreamer)                         |
+| Per-program transaction history backfill                       | [`transaction-crawler-rpc`](transaction-crawler-rpc) |
+| Loading current state via RPC `getProgramAccounts`             | [`gpa-rpc`](gpa-rpc)                                 |
+| Loading state from a validator snapshot file                   | [`snapshot-validator`](snapshot-validator)           |
+| Indexing a program upgraded with a breaking IDL change         | [`versioned-decoders`](versioned-decoders)           |
+| Persisting decoded data to Postgres and serving it via GraphQL | [`postgres-graphql`](postgres-graphql)               |
+| Implementing your own `Datasource`                             | [`custom-datasource`](custom-datasource)             |
 
 ## Variants
 
 A few examples ship with interchangeable upstream sources, defined side-by-side in `src/variants.rs`. The processor and pipeline wiring stay identical across variants — to swap, edit the single line in `main.rs` that constructs the datasource.
 
-| Crate                                                | Default                       | Alternatives                                                                                                                        |
-| ---------------------------------------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| [`yellowstone-grpc`](yellowstone-grpc)               | Yellowstone Geyser gRPC       | Helius LaserStream gRPC (`replay_enabled` for missed-slot replay); Jito Shredstream gRPC (pre-confirmation, no source-side filters) |
-| [`transaction-crawler-rpc`](transaction-crawler-rpc) | RPC `getSignaturesForAddress` | Helius GTFA (hosted, with built-in slot/time/status filters)                                                                        |
-| [`gpa-rpc`](gpa-rpc)                                 | RPC `getProgramAccounts`      | Helius gPA v2 (paginated, `changed_since_slot` for incremental syncs)                                                               |
+| Crate                                                | Default                       | Alternatives                                                          |
+| ---------------------------------------------------- | ----------------------------- | --------------------------------------------------------------------- |
+| [`yellowstone-grpc`](yellowstone-grpc)               | Yellowstone Geyser gRPC       | Helius LaserStream gRPC (`replay_enabled` for missed-slot replay)     |
+| [`transaction-crawler-rpc`](transaction-crawler-rpc) | RPC `getSignaturesForAddress` | Helius GTFA (hosted, with built-in slot/time/status filters)          |
+| [`gpa-rpc`](gpa-rpc)                                 | RPC `getProgramAccounts`      | Helius gPA v2 (paginated, `changed_since_slot` for incremental syncs) |
 
 ## Running
 

--- a/examples/block-subscribe-rpc/Cargo.toml
+++ b/examples/block-subscribe-rpc/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "block-subscribe-rpc-carbon-example"
-version = "1.0.0"
+version = "2.0.0"
+publish = false
+rust-version = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]

--- a/examples/custom-datasource/Cargo.toml
+++ b/examples/custom-datasource/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "custom-datasource-carbon-example"
-version = "1.0.0"
+version = "2.0.0"
+publish = false
+rust-version = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]

--- a/examples/gpa-rpc/Cargo.toml
+++ b/examples/gpa-rpc/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "gpa-rpc-carbon-example"
-version = "1.0.0"
+version = "2.0.0"
+publish = false
+rust-version = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]

--- a/examples/jetstreamer/Cargo.toml
+++ b/examples/jetstreamer/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "jetstreamer-carbon-example"
 version = "1.0.0"
+publish = false
 edition = { workspace = true }
 
 [dependencies]

--- a/examples/jetstreamer/README.md
+++ b/examples/jetstreamer/README.md
@@ -1,17 +1,20 @@
 # Jetstreamer Example
 
+> [!NOTE]
+> This is a Carbon 1 / Solana 3 example. It is excluded from the Carbon 2
+> workspace because Jetstreamer does not yet support the Solana v4 stack.
+> It is retained as an archival reference and is not buildable from this Carbon
+> 2 checkout; use the published 1.x datasource in a Carbon 1 application.
+
 This example demonstrates how to backfill historical Token-2022 activity over a slot range via the Jetstream API (Solana Foundation's Old Faithful archive). It uses upstream-side transaction filtering (only matching transactions are returned), multi-threaded fetch for higher throughput than serial RPC polling, and exits cleanly via `ProcessPending` when the slot range drains.
 
 ## Setup Instructions
 
-### Step 1: Clone the Repository
+### Step 1: Use a Carbon 1 project
 
-To get started, clone the repository:
-
-```sh
-git clone git@github.com:sevenlabs-hq/carbon.git
-cd carbon/examples/jetstreamer
-```
+Copy this example's configuration and processor pattern into an application
+that consistently uses the published Carbon 1.x crates. Do not add it to the
+Carbon 2 workspace.
 
 ### Step 2: Set Environment Variables
 

--- a/examples/postgres-graphql/Cargo.toml
+++ b/examples/postgres-graphql/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "postgres-graphql-carbon-example"
-version = "1.0.0"
+version = "2.0.0"
+publish = false
+rust-version = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]

--- a/examples/snapshot-validator/Cargo.toml
+++ b/examples/snapshot-validator/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "snapshot-validator-carbon-example"
-version = "1.0.0"
+version = "2.0.0"
+publish = false
+rust-version = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]

--- a/examples/transaction-crawler-rpc/Cargo.toml
+++ b/examples/transaction-crawler-rpc/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "transaction-crawler-rpc-carbon-example"
-version = "1.0.0"
+version = "2.0.0"
+publish = false
+rust-version = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]

--- a/examples/versioned-decoders/Cargo.toml
+++ b/examples/versioned-decoders/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "versioned-decoders-carbon-example"
-version = "1.0.0"
+version = "2.0.0"
+publish = false
+rust-version = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]

--- a/examples/versioned-decoders/decoder-v1/Cargo.toml
+++ b/examples/versioned-decoders/decoder-v1/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-simple-dex-decoder-v1"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 publish = false
 

--- a/examples/versioned-decoders/decoder-v2/Cargo.toml
+++ b/examples/versioned-decoders/decoder-v2/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-simple-dex-decoder-v2"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 edition = { workspace = true }
 publish = false
 

--- a/examples/yellowstone-grpc/Cargo.toml
+++ b/examples/yellowstone-grpc/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "yellowstone-grpc-carbon-example"
-version = "1.0.0"
+version = "2.0.0"
+publish = false
+rust-version = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]

--- a/metrics/log-metrics/Cargo.toml
+++ b/metrics/log-metrics/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-log-metrics"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 description = "Log Metrics"
 license = { workspace = true }
 edition = { workspace = true }

--- a/metrics/prometheus-metrics/Cargo.toml
+++ b/metrics/prometheus-metrics/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "carbon-prometheus-metrics"
-version = "1.0.0"
+version = "2.0.0"
+rust-version = { workspace = true }
 description = "Prometheus Metrics"
 license = { workspace = true }
 edition = { workspace = true }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "packageManager": "pnpm@9.6.0",
     "engines": {
         "node": ">=20.18.0",
-        "pnpm": ">=8.0.0"
+        "pnpm": "9.6.0"
     },
     "pnpm": {
         "overrides": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     },
     "packageManager": "pnpm@9.6.0",
     "engines": {
-        "node": ">=18.0.0",
+        "node": ">=20.18.0",
         "pnpm": ">=8.0.0"
     },
     "pnpm": {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -118,7 +118,6 @@ carbon-cli scaffold
 - `rpc-transaction-crawler` - Crawls historical transactions
 - `helius-laserstream` - Helius Laserstream datasource
 - `yellowstone-grpc` - Yellowstone gRPC datasource
-- `jito-shredstream-grpc` - JITO Shredstream gRPC
 
 ## Related Packages
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,9 +30,9 @@
     },
     "exports": {
         ".": {
-            "import": "./dist/index.mjs",
-            "require": "./dist/index.js",
-            "types": "./dist/index.d.ts"
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.js",
+            "require": "./dist/index.cjs"
         }
     },
     "files": [
@@ -42,6 +42,7 @@
     "scripts": {
         "build": "tsup",
         "dev": "tsup --watch",
+        "test": "node --test tests/*.test.mjs",
         "type-check": "tsc --noEmit",
         "clean": "rimraf dist"
     },
@@ -68,6 +69,6 @@
         "typescript": "^5.8.3"
     },
     "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.18.0"
     }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sevenlabs-hq/carbon-cli",
-    "version": "0.12.0",
+    "version": "0.13.0",
     "description": "Generate decoders and scaffold indexers for Solana programs from Anchor or Codama IDL",
     "keywords": [
         "solana",

--- a/packages/cli/src/datasources/rpc_block_subscribe.ts
+++ b/packages/cli/src/datasources/rpc_block_subscribe.ts
@@ -4,6 +4,7 @@ export function buildRpcBlockSubscribe(_decoders: DecoderMeta[]): DatasourceArti
     const imports = [
         'carbon_rpc_block_subscribe_datasource::{Filters, RpcBlockSubscribe}',
         'solana_client::rpc_config::{RpcBlockSubscribeConfig, RpcBlockSubscribeFilter}',
+        'solana_transaction_status::{TransactionDetails, UiTransactionEncoding}',
     ];
 
     const init = `
@@ -11,6 +12,8 @@ export function buildRpcBlockSubscribe(_decoders: DecoderMeta[]): DatasourceArti
         let filters = Filters::new(
             RpcBlockSubscribeFilter::All,
             Some(RpcBlockSubscribeConfig {
+                encoding: Some(UiTransactionEncoding::Base64),
+                transaction_details: Some(TransactionDetails::Full),
                 max_supported_transaction_version: Some(1),
                 ..RpcBlockSubscribeConfig::default()
             }),

--- a/packages/cli/src/lib/cargoTomlGenerator.ts
+++ b/packages/cli/src/lib/cargoTomlGenerator.ts
@@ -1,5 +1,5 @@
 import { kebabCase } from '@codama/nodes';
-import { VERSIONS, getCrateDependencyString } from '@sevenlabs-hq/carbon-versions';
+import { CARBON_MSRV, VERSIONS, getCrateDependencyString } from '@sevenlabs-hq/carbon-versions';
 import type { ScaffoldOptions } from './scaffold';
 import { exitWithError } from './utils';
 
@@ -20,10 +20,14 @@ export function generateIndexerCargoToml(opts: ScaffoldOptions): string {
     if (opts.withSerde) decoderFeatures.push('serde');
     if (opts.withBase58) decoderFeatures.push('base58');
 
-    const carbonCoreDep = getCrateDependencyString('carbon-core', VERSIONS['carbon-core'], ['postgres', 'graphql']);
+    const coreFeatures: string[] = [];
+    if (opts.withPostgres) coreFeatures.push('postgres');
+    if (opts.withGraphql) coreFeatures.push('graphql');
+    const carbonCoreDep = getCrateDependencyString('carbon-core', VERSIONS['carbon-core'], coreFeatures);
     const tokioDep = getCrateDependencyString('tokio', VERSIONS['tokio']);
     const dotenvDep = getCrateDependencyString('dotenv', VERSIONS['dotenv']);
     const envLoggerDep = getCrateDependencyString('env_logger', VERSIONS['env_logger']);
+    const logDep = getCrateDependencyString('log', VERSIONS.log);
 
     const decoderFeaturesStr =
         decoderFeatures.length > 0 ? `, features = [${decoderFeatures.map(f => `"${f}"`).join(', ')}]` : '';
@@ -55,9 +59,19 @@ export function generateIndexerCargoToml(opts: ScaffoldOptions): string {
             ? getCrateDependencyString('solana-commitment-config', VERSIONS['solana-commitment-config'])
             : null;
 
-    const programDeps =
+    const rpcClientDep =
+        opts.dataSource === 'rpc-block-subscribe' || opts.dataSource === 'rpc-program-subscribe'
+            ? getCrateDependencyString('solana-client', VERSIONS['solana-client'])
+            : null;
+
+    const programDep =
         opts.dataSource === 'rpc-program-subscribe'
             ? getCrateDependencyString('solana-account-decoder', VERSIONS['solana-account-decoder'])
+            : null;
+
+    const blockSubscribeDep =
+        opts.dataSource === 'rpc-block-subscribe'
+            ? getCrateDependencyString('solana-transaction-status', VERSIONS['solana-transaction-status'])
             : null;
 
     const pgDeps = opts.withPostgres
@@ -82,11 +96,19 @@ export function generateIndexerCargoToml(opts: ScaffoldOptions): string {
     if (crawlerDeps) {
         dependencies.push(crawlerDeps);
     }
-    if (programDeps) {
-        dependencies.push(programDeps);
+    if (rpcClientDep) {
+        dependencies.push(rpcClientDep);
     }
 
-    dependencies.push(tokioDep, dotenvDep, envLoggerDep);
+    if (programDep) {
+        dependencies.push(programDep);
+    }
+
+    if (blockSubscribeDep) {
+        dependencies.push(blockSubscribeDep);
+    }
+
+    dependencies.push(tokioDep, dotenvDep, envLoggerDep, logDep);
 
     if (rustlsDep) {
         dependencies.push(rustlsDep);
@@ -106,6 +128,7 @@ export function generateIndexerCargoToml(opts: ScaffoldOptions): string {
         `name = "${opts.name}-indexer"`,
         'version = "0.0.1"',
         'edition = "2021"',
+        `rust-version = "${CARBON_MSRV}"`,
         '',
         '[dependencies]',
         ...dependencies,

--- a/packages/cli/src/lib/prompts.ts
+++ b/packages/cli/src/lib/prompts.ts
@@ -335,12 +335,14 @@ export async function promptForScaffold(existingOpts: ScaffoldOptions = {}): Pro
     }
 
     const withGraphql =
-        existingOpts.withGraphql !== undefined
-            ? existingOpts.withGraphql
-            : await confirm({
-                  message: 'Enable GraphQL API for querying data?',
-                  default: true,
-              });
+        !withPostgres && existingOpts.withGraphql === undefined
+            ? false
+            : existingOpts.withGraphql !== undefined
+              ? existingOpts.withGraphql
+              : await confirm({
+                    message: 'Enable GraphQL API for querying data?',
+                    default: true,
+                });
 
     return {
         name,

--- a/packages/cli/src/lib/scaffold.ts
+++ b/packages/cli/src/lib/scaffold.ts
@@ -1,6 +1,5 @@
 import { mkdirSync, writeFileSync, existsSync } from 'fs';
-import { dirname, join } from 'path';
-import { fileURLToPath } from 'url';
+import { join } from 'path';
 import nunjucks from 'nunjucks';
 import { exitWithError } from './utils';
 import { kebabCase } from '@codama/nodes';
@@ -32,14 +31,11 @@ function buildProjectImports(ctx: any): string {
     const lines: string[] = [];
 
     // Common
-    lines.push('use std::{env, sync::Arc};');
+    lines.push(ctx.withPostgres ? 'use std::{env, sync::Arc};' : 'use std::sync::Arc;');
 
     // Feature-dependent
     if (!ctx.withPostgres) {
-        lines.push('use async_trait::async_trait;');
-        lines.push('use carbon_core::deserialize::ArrangeAccounts;');
-        lines.push('use carbon_core::instruction::{InstructionMetadata, NestedInstructions};');
-        lines.push('use carbon_core::metrics::MetricsCollection;');
+        lines.push('use carbon_core::instruction::InstructionProcessorInputType;');
         lines.push('use carbon_core::processor::Processor;');
     }
 
@@ -127,6 +123,10 @@ function getEnvContent(artifact: DatasourceArtifact | undefined, withPostgres: b
 }
 
 export function renderScaffold(opts: ScaffoldOptions) {
+    if (opts.withGraphql && !opts.withPostgres) {
+        exitWithError('GraphQL scaffolding requires Postgres. Enable --with-postgres or disable --with-graphql.');
+    }
+
     const base = join(opts.outDir, opts.name);
 
     if (existsSync(base) && !opts.force) {
@@ -140,8 +140,7 @@ export function renderScaffold(opts: ScaffoldOptions) {
     ensureDir(indexerDir);
     ensureDir(join(indexerDir, 'src'));
 
-    const thisDir = dirname(fileURLToPath(import.meta.url));
-    const templatesDir = join(thisDir, '..', 'templates');
+    const templatesDir = join(__dirname, '..', 'templates');
 
     if (!existsSync(join(templatesDir, 'project.njk'))) {
         exitWithError('Template file not found. Please ensure cli/templates/project.njk exists.');

--- a/packages/cli/templates/project.njk
+++ b/packages/cli/templates/project.njk
@@ -116,25 +116,16 @@ async fn run_graphql(pool: Arc<sqlx::PgPool>) -> CarbonResult<()> {
 {%- for decoder in decoders %} 
 pub struct {{ decoder.name }}InstructionProcessor;
 
-#[async_trait]
-impl Processor for {{ decoder.name }}InstructionProcessor {
-    type InputType = (
-        InstructionMetadata,
-        {{ decoder.name }}Instruction,
-        NestedInstructions,
-        solana_instruction::Instruction,
-    );
-
+impl Processor<InstructionProcessorInputType<'_, {{ decoder.name }}Instruction>> for {{ decoder.name }}InstructionProcessor {
     async fn process(
         &mut self,
-        (metadata, decoded_instruction, _nested_instructions, _raw_instruction): Self::InputType,
-        _metrics: Arc<MetricsCollection>,
+        input: &InstructionProcessorInputType<'_, {{ decoder.name }}Instruction>,
     ) -> CarbonResult<()> {
-        let signature = metadata.transaction_metadata.signature;
+        let signature = input.metadata.transaction_metadata.signature;
 
         log::info!("received the {{ decoder.name }} instruction, sig: {}", signature);
-        
-        match decoded_instruction {
+
+        match input.decoded_instruction {
             _ => {}
         };
 

--- a/packages/cli/tests/fixtures/minimal-anchor.json
+++ b/packages/cli/tests/fixtures/minimal-anchor.json
@@ -1,0 +1,16 @@
+{
+    "address": "11111111111111111111111111111111",
+    "metadata": {
+        "name": "smoke",
+        "version": "0.1.0",
+        "spec": "0.1.0"
+    },
+    "instructions": [
+        {
+            "name": "ping",
+            "discriminator": [1],
+            "accounts": [],
+            "args": []
+        }
+    ]
+}

--- a/packages/cli/tests/package-artifacts.test.mjs
+++ b/packages/cli/tests/package-artifacts.test.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const packageDirectory = dirname(dirname(fileURLToPath(import.meta.url)));
+const packageJson = JSON.parse(readFileSync(join(packageDirectory, 'package.json'), 'utf8'));
+
+test('published entry points exist in the built package', () => {
+    const entryPoints = [...Object.values(packageJson.bin), ...Object.values(packageJson.exports['.'])];
+
+    for (const entryPoint of entryPoints) {
+        assert.ok(existsSync(join(packageDirectory, entryPoint)), `missing package entry point: ${entryPoint}`);
+    }
+});

--- a/packages/cli/tests/scaffold-output.test.mjs
+++ b/packages/cli/tests/scaffold-output.test.mjs
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const packageDirectory = dirname(dirname(fileURLToPath(import.meta.url)));
+
+test('scaffolds a Carbon 2 Transaction V1-ready RPC project', () => {
+    const outputDirectory = mkdtempSync(join(tmpdir(), 'carbon-cli-v2-scaffold-'));
+
+    try {
+        const result = spawnSync(
+            process.execPath,
+            [
+                join(packageDirectory, 'dist/cli.js'),
+                'scaffold',
+                '--name',
+                'release-smoke',
+                '--out-dir',
+                outputDirectory,
+                '--decoder',
+                'smoke',
+                '--idl',
+                join(packageDirectory, 'tests/fixtures/minimal-anchor.json'),
+                '--idl-standard',
+                'anchor',
+                '--data-source',
+                'rpc-block-subscribe',
+                '--metrics',
+                'log',
+                '--with-postgres',
+                'false',
+                '--with-graphql',
+                'false',
+                '--with-serde',
+                'true',
+            ],
+            { cwd: packageDirectory, encoding: 'utf8' },
+        );
+
+        assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+
+        const projectDirectory = join(outputDirectory, 'release-smoke');
+        const cargoToml = readFileSync(join(projectDirectory, 'indexer/Cargo.toml'), 'utf8');
+        const decoderCargoToml = readFileSync(join(projectDirectory, 'decoder/Cargo.toml'), 'utf8');
+        const main = readFileSync(join(projectDirectory, 'indexer/src/main.rs'), 'utf8');
+
+        const cargoFmt = spawnSync(
+            'cargo',
+            ['fmt', '--all', '--check', '--manifest-path', join(projectDirectory, 'Cargo.toml')],
+            { cwd: projectDirectory, encoding: 'utf8' },
+        );
+        assert.equal(cargoFmt.status, 0, `${cargoFmt.stdout}\n${cargoFmt.stderr}`);
+
+        assert.match(cargoToml, /rust-version = "1\.96\.1"/);
+        assert.match(decoderCargoToml, /rust-version = "1\.96\.1"/);
+        assert.match(cargoToml, /carbon-core = \{ version = "2\.0\.0", default-features = false \}/);
+        assert.doesNotMatch(cargoToml, /features = \["postgres", "graphql"\]/);
+        assert.match(cargoToml, /carbon-rpc-block-subscribe-datasource = "2\.0\.0"/);
+        assert.match(cargoToml, /solana-client = "=4\.2\.2"/);
+        assert.match(
+            cargoToml,
+            /solana-transaction-status = \{ version = "=4\.2\.2", features = \["agave-unstable-api"\] \}/,
+        );
+        assert.match(cargoToml, /log = "0\.4\.28"/);
+
+        assert.match(main, /encoding: Some\(UiTransactionEncoding::Base64\)/);
+        assert.match(main, /transaction_details: Some\(TransactionDetails::Full\)/);
+        assert.match(main, /max_supported_transaction_version: Some\(1\)/);
+        assert.match(main, /impl Processor<InstructionProcessorInputType<'_, SmokeInstruction>>/);
+        assert.match(main, /input: &InstructionProcessorInputType<'_, SmokeInstruction>/);
+        assert.doesNotMatch(main, /async_trait|MetricsCollection|NestedInstructions/);
+    } finally {
+        rmSync(outputDirectory, { force: true, recursive: true });
+    }
+});
+
+test('rejects GraphQL scaffolding without Postgres', () => {
+    const outputDirectory = mkdtempSync(join(tmpdir(), 'carbon-cli-invalid-scaffold-'));
+
+    try {
+        const result = spawnSync(
+            process.execPath,
+            [
+                join(packageDirectory, 'dist/cli.js'),
+                'scaffold',
+                '--name',
+                'invalid-graphql',
+                '--out-dir',
+                outputDirectory,
+                '--decoder',
+                'smoke',
+                '--idl',
+                join(packageDirectory, 'tests/fixtures/minimal-anchor.json'),
+                '--idl-standard',
+                'anchor',
+                '--data-source',
+                'rpc-block-subscribe',
+                '--metrics',
+                'log',
+                '--with-postgres',
+                'false',
+                '--with-graphql',
+                'true',
+            ],
+            { cwd: packageDirectory, encoding: 'utf8' },
+        );
+
+        assert.equal(result.status, 2, `${result.stdout}\n${result.stderr}`);
+        assert.match(result.stderr, /GraphQL scaffolding requires Postgres/);
+    } finally {
+        rmSync(outputDirectory, { force: true, recursive: true });
+    }
+});

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
     entry: ['src/cli.ts', 'src/index.ts'],
     format: ['cjs', 'esm'],
     dts: true,
+    shims: true,
     sourcemap: true,
     clean: true,
     target: 'es2022',

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -39,7 +39,7 @@
         "dev": "tsup --watch",
         "type-check": "tsc --noEmit",
         "lint": "echo 'No linting configured'",
-        "test": "tsup && cp -r templates dist/ && node --test tests/*.test.mjs",
+        "test": "node --test tests/*.test.mjs",
         "clean": "rimraf dist"
     },
     "dependencies": {
@@ -58,6 +58,6 @@
         "typescript": "^5.8.3"
     },
     "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.18.0"
     }
 }

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sevenlabs-hq/carbon-codama-renderer",
-    "version": "0.12.0",
+    "version": "0.13.0",
     "description": "Carbon codama renderer for Codama IDL",
     "keywords": [
         "solana",

--- a/packages/renderer/src/cargoTomlGenerator.ts
+++ b/packages/renderer/src/cargoTomlGenerator.ts
@@ -1,5 +1,5 @@
 import { kebabCase } from '@codama/nodes';
-import { VERSIONS, getCrateDependencyString } from '@sevenlabs-hq/carbon-versions';
+import { CARBON_MSRV, VERSIONS, getCrateDependencyString } from '@sevenlabs-hq/carbon-versions';
 import { isToken2022Program } from './utils/helpers';
 
 export type PackageMetadata = {
@@ -288,6 +288,7 @@ export function generateDecoderCargoToml(options: DecoderCargoTomlOptions): stri
         `name = "${decoderPackageName}"`,
         `version = "${version}"`,
         useWorkspace ? 'edition = { workspace = true }' : 'edition = "2021"',
+        useWorkspace ? 'rust-version = { workspace = true }' : `rust-version = "${CARBON_MSRV}"`,
     ];
     if (hasMeta) {
         packageLines.push(`description = "${description.replace(/"/g, '\\"')}"`);

--- a/packages/renderer/src/utils/render.ts
+++ b/packages/renderer/src/utils/render.ts
@@ -1,5 +1,4 @@
-import { dirname as pathDirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 
 import { camelCase, kebabCase, pascalCase, snakeCase, titleCase } from '@codama/nodes';
 import nunjucks, { ConfigureOptions as NunJucksOptions } from 'nunjucks';
@@ -65,9 +64,7 @@ export function formatDocComments(docs: string[], indent: string = ''): string {
 }
 
 export const render = (template: string, context?: object, options?: NunJucksOptions): string => {
-    const isESM = typeof import.meta !== 'undefined';
-    const dirname = isESM ? pathDirname(fileURLToPath(import.meta.url)) : __dirname;
-    const templates = join(dirname, '..', 'templates');
+    const templates = join(__dirname, '..', 'templates');
 
     const env = nunjucks.configure(templates, { autoescape: false, trimBlocks: true, ...options });
 

--- a/packages/renderer/tests/native-events.test.mjs
+++ b/packages/renderer/tests/native-events.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -25,6 +26,37 @@ import {
 import { visit } from '@codama/visitors-core';
 
 import { renderVisitor } from '../dist/index.mjs';
+
+const require = createRequire(import.meta.url);
+const { renderVisitor: renderVisitorCjs } = require('../dist/index.js');
+
+test('renders through the CommonJS entry point', () => {
+    const outputDirectory = mkdtempSync(join(tmpdir(), 'carbon-cjs-render-'));
+
+    try {
+        const root = rootNode(
+            programNode({
+                name: 'commonJsSmoke',
+                publicKey: '11111111111111111111111111111111',
+                instructions: [instructionNode({ name: 'ping' })],
+            }),
+        );
+
+        visit(
+            root,
+            renderVisitorCjs(outputDirectory, {
+                standalone: true,
+                withGraphql: false,
+                withPostgres: false,
+                withSerde: true,
+            }),
+        );
+
+        assert.ok(existsSync(join(outputDirectory, 'src/lib.rs')));
+    } finally {
+        rmSync(outputDirectory, { force: true, recursive: true });
+    }
+});
 
 test('renders native Codama events with their IDL-defined CPI discriminator', () => {
     const outputDirectory = mkdtempSync(join(tmpdir(), 'carbon-codama-events-'));
@@ -79,8 +111,9 @@ test('renders native Codama events with their IDL-defined CPI discriminator', ()
         assert.match(lib, /pub const EVENT_CPI_DISCRIMINATOR: &\[u8\] = &\[1, 2, 3, 4\];/);
 
         const cargoToml = readFileSync(join(outputDirectory, 'Cargo.toml'), 'utf8');
-        assert.match(cargoToml, /carbon-core = \{ version = "1\.0\.0"/);
-        assert.match(cargoToml, /carbon-test-utils = "1\.0\.0"/);
+        assert.match(cargoToml, /rust-version = "1\.96\.1"/);
+        assert.match(cargoToml, /carbon-core = \{ version = "2\.0\.0"/);
+        assert.match(cargoToml, /carbon-test-utils = "2\.0\.0"/);
     } finally {
         rmSync(outputDirectory, { force: true, recursive: true });
     }

--- a/packages/renderer/tsup.config.ts
+++ b/packages/renderer/tsup.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     format: ['cjs', 'esm'],
     dts: true,
     splitting: false,
+    shims: true,
     sourcemap: true,
     clean: true,
     minify: false,

--- a/packages/renderer/tsup.config.ts
+++ b/packages/renderer/tsup.config.ts
@@ -14,6 +14,6 @@ export default defineConfig({
     define: {
         __ESM__: 'true',
         __TEST__: 'false',
-        __VERSION__: '"1.0.0"',
+        __VERSION__: '"0.13.0"',
     },
 });

--- a/packages/versions/README.md
+++ b/packages/versions/README.md
@@ -2,4 +2,4 @@
 
 Centralized version registry for Carbon Rust crate versions.
 
-This package version matches the Rust workspace version and provides constants for all Rust dependencies used in Carbon code generation.
+It exports the current supported Carbon Rust release and compatible third-party dependencies used in code generation. The npm package and Rust workspace use independent release numbers.

--- a/packages/versions/package.json
+++ b/packages/versions/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sevenlabs-hq/carbon-versions",
-    "version": "0.12.0",
+    "version": "0.13.0",
     "description": "Carbon version registry for Rust crate versions",
     "keywords": [
         "carbon",

--- a/packages/versions/package.json
+++ b/packages/versions/package.json
@@ -34,6 +34,7 @@
     "scripts": {
         "build": "tsup",
         "dev": "tsup --watch",
+        "test": "node --test tests/*.test.mjs",
         "type-check": "tsc --noEmit",
         "clean": "rimraf dist"
     },
@@ -43,6 +44,6 @@
         "typescript": "^5.8.3"
     },
     "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.18.0"
     }
 }

--- a/packages/versions/src/index.ts
+++ b/packages/versions/src/index.ts
@@ -2,7 +2,7 @@
  * Carbon Version Registry
  *
  * Centralized registry for all Rust crate versions used in Carbon code generation.
- * This package version matches the Rust workspace version.
+ * Carbon-owned entries track the current supported Rust release line.
  */
 
 export type CrateDependency =
@@ -16,24 +16,30 @@ export type CrateDependency =
           defaultFeatures?: boolean;
       };
 
+export const CARBON_VERSION = '2.0.0';
+export const CARBON_MSRV = '1.96.1';
+
 export const VERSIONS: Record<string, CrateDependency> = {
     /// Carbon crates
     'carbon-core': {
-        version: '1.0.0',
+        version: CARBON_VERSION,
         defaultFeatures: false,
     },
-    'carbon-test-utils': '1.0.0',
-    'carbon-log-metrics': '1.0.0',
-    'carbon-prometheus-metrics': '1.0.0',
-    'carbon-helius-atlas-ws-datasource': '1.0.0',
-    'carbon-helius-laserstream-datasource': '1.0.0',
-    'carbon-jito-shredstream-grpc-datasource': '0.12.0',
-    'carbon-rpc-block-crawler-datasource': '1.0.0',
-    'carbon-rpc-block-subscribe-datasource': '1.0.0',
-    'carbon-rpc-program-subscribe-datasource': '1.0.0',
-    'carbon-rpc-transaction-crawler-datasource': '1.0.0',
-    'carbon-stream-message-datasource': '1.0.0',
-    'carbon-yellowstone-grpc-datasource': '1.0.0',
+    'carbon-test-utils': CARBON_VERSION,
+    'carbon-log-metrics': CARBON_VERSION,
+    'carbon-prometheus-metrics': CARBON_VERSION,
+    'carbon-helius-atlas-ws-datasource': CARBON_VERSION,
+    'carbon-helius-gpa-v2-datasource': CARBON_VERSION,
+    'carbon-helius-gtfa-datasource': CARBON_VERSION,
+    'carbon-helius-laserstream-datasource': CARBON_VERSION,
+    'carbon-rpc-block-crawler-datasource': CARBON_VERSION,
+    'carbon-rpc-block-subscribe-datasource': CARBON_VERSION,
+    'carbon-rpc-gpa-datasource': CARBON_VERSION,
+    'carbon-rpc-program-subscribe-datasource': CARBON_VERSION,
+    'carbon-rpc-transaction-crawler-datasource': CARBON_VERSION,
+    'carbon-stream-message-datasource': CARBON_VERSION,
+    'carbon-validator-snapshot-datasource': CARBON_VERSION,
+    'carbon-yellowstone-grpc-datasource': CARBON_VERSION,
     /// Solana crates
     'solana-account': '4.3.2',
     'solana-account-decoder': {
@@ -50,6 +56,10 @@ export const VERSIONS: Record<string, CrateDependency> = {
         features: ['borsh'],
     },
     'solana-commitment-config': '3.1.1',
+    'solana-transaction-status': {
+        version: '=4.2.2',
+        features: ['agave-unstable-api'],
+    },
     /// SPL Token 2022 dependencies
     'solana-program-pack': '3.1.0',
     'spl-token-2022': '11.0.0',

--- a/packages/versions/tests/versions.test.mjs
+++ b/packages/versions/tests/versions.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { CARBON_MSRV, CARBON_VERSION, VERSIONS } from '../dist/index.mjs';
+
+const V2_DATASOURCES = [
+    'carbon-helius-atlas-ws-datasource',
+    'carbon-helius-gpa-v2-datasource',
+    'carbon-helius-gtfa-datasource',
+    'carbon-helius-laserstream-datasource',
+    'carbon-rpc-block-crawler-datasource',
+    'carbon-rpc-block-subscribe-datasource',
+    'carbon-rpc-gpa-datasource',
+    'carbon-rpc-program-subscribe-datasource',
+    'carbon-rpc-transaction-crawler-datasource',
+    'carbon-stream-message-datasource',
+    'carbon-validator-snapshot-datasource',
+    'carbon-yellowstone-grpc-datasource',
+];
+
+function versionOf(dependency) {
+    return typeof dependency === 'string' ? dependency : dependency?.version;
+}
+
+test('pins the supported Carbon release line consistently', () => {
+    assert.equal(CARBON_VERSION, '2.0.0');
+    assert.equal(CARBON_MSRV, '1.96.1');
+
+    for (const [crate, dependency] of Object.entries(VERSIONS).filter(([crate]) => crate.startsWith('carbon-'))) {
+        assert.equal(versionOf(dependency), CARBON_VERSION, `${crate} must track Carbon ${CARBON_VERSION}`);
+    }
+});
+
+test('lists all and only the supported v2 datasource crates', () => {
+    const datasourceCrates = Object.keys(VERSIONS)
+        .filter(crate => crate.startsWith('carbon-') && crate.endsWith('-datasource'))
+        .sort();
+
+    assert.deepEqual(datasourceCrates, [...V2_DATASOURCES].sort());
+    assert.equal(VERSIONS['carbon-jetstreamer-datasource'], undefined);
+    assert.equal(VERSIONS['carbon-jito-shredstream-grpc-datasource'], undefined);
+});

--- a/scripts/publish-crate.sh
+++ b/scripts/publish-crate.sh
@@ -8,23 +8,21 @@ workspace_crates=(
     carbon-test-utils
     carbon-core
 
+    carbon-log-metrics
+    carbon-prometheus-metrics
+
     carbon-helius-atlas-ws-datasource
     carbon-helius-gpa-v2-datasource
     carbon-helius-gtfa-datasource
     carbon-helius-laserstream-datasource
-    carbon-jetstreamer-datasource
     carbon-rpc-block-crawler-datasource
     carbon-rpc-block-subscribe-datasource
     carbon-rpc-gpa-datasource
     carbon-rpc-program-subscribe-datasource
     carbon-rpc-transaction-crawler-datasource
-    carbon-jito-shredstream-grpc-datasource
-    carbon-yellowstone-grpc-datasource
     carbon-stream-message-datasource
     carbon-validator-snapshot-datasource
-
-    carbon-log-metrics
-    carbon-prometheus-metrics
+    carbon-yellowstone-grpc-datasource
 
     carbon-address-lookup-table-decoder
     carbon-associated-token-account-decoder
@@ -53,10 +51,10 @@ workspace_crates=(
     carbon-marinade-finance-decoder
     carbon-memo-program-decoder
     carbon-meteora-damm-v2-decoder
+    carbon-meteora-dbc-decoder
     carbon-meteora-dlmm-decoder
     carbon-meteora-pools-decoder
     carbon-meteora-vault-decoder
-    carbon-meteora-dbc-decoder
     carbon-moonshot-decoder
     carbon-mpl-core-decoder
     carbon-mpl-token-metadata-decoder
@@ -67,8 +65,8 @@ workspace_crates=(
     carbon-orca-whirlpool-decoder
     carbon-pancake-swap-decoder
     carbon-phoenix-v1-decoder
-    carbon-pump-swap-decoder
     carbon-pump-fees-decoder
+    carbon-pump-swap-decoder
     carbon-pumpfun-decoder
     carbon-raydium-amm-v4-decoder
     carbon-raydium-clmm-decoder
@@ -89,11 +87,10 @@ workspace_crates=(
     carbon-virtuals-decoder
     carbon-wavebreak-decoder
     carbon-zeta-decoder
-   
 )
 
 for crate in "${workspace_crates[@]}"; do
     echo "--- $crate"
-    # cargo package -p $crate
-    cargo publish -p $crate --allow-dirty
+    # cargo package -p "$crate"
+    cargo publish -p "$crate" --allow-dirty
 done

--- a/scripts/yank-crates.sh
+++ b/scripts/yank-crates.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-VERSION="${VERSION:-1.0.0}"
+VERSION="${VERSION:-2.0.0}"
 
 workspace_crates=(
     carbon-macros
@@ -10,22 +10,21 @@ workspace_crates=(
     carbon-test-utils
     carbon-core
 
+    carbon-log-metrics
+    carbon-prometheus-metrics
+
     carbon-helius-atlas-ws-datasource
     carbon-helius-gpa-v2-datasource
     carbon-helius-gtfa-datasource
     carbon-helius-laserstream-datasource
-    carbon-jetstreamer-datasource
     carbon-rpc-block-crawler-datasource
     carbon-rpc-block-subscribe-datasource
     carbon-rpc-gpa-datasource
     carbon-rpc-program-subscribe-datasource
     carbon-rpc-transaction-crawler-datasource
-    carbon-jito-shredstream-grpc-datasource
+    carbon-stream-message-datasource
+    carbon-validator-snapshot-datasource
     carbon-yellowstone-grpc-datasource
-    carbon-stream-message-datasource 
-
-    carbon-log-metrics
-    carbon-prometheus-metrics
 
     carbon-address-lookup-table-decoder
     carbon-associated-token-account-decoder
@@ -54,10 +53,10 @@ workspace_crates=(
     carbon-marinade-finance-decoder
     carbon-memo-program-decoder
     carbon-meteora-damm-v2-decoder
+    carbon-meteora-dbc-decoder
     carbon-meteora-dlmm-decoder
     carbon-meteora-pools-decoder
     carbon-meteora-vault-decoder
-    carbon-meteora-dbc-decoder
     carbon-moonshot-decoder
     carbon-mpl-core-decoder
     carbon-mpl-token-metadata-decoder
@@ -68,8 +67,8 @@ workspace_crates=(
     carbon-orca-whirlpool-decoder
     carbon-pancake-swap-decoder
     carbon-phoenix-v1-decoder
-    carbon-pump-swap-decoder
     carbon-pump-fees-decoder
+    carbon-pump-swap-decoder
     carbon-pumpfun-decoder
     carbon-raydium-amm-v4-decoder
     carbon-raydium-clmm-decoder
@@ -86,7 +85,6 @@ workspace_crates=(
     carbon-system-program-decoder
     carbon-token-2022-decoder
     carbon-token-program-decoder
-    carbon-validator-snapshot-datasource
     carbon-vertigo-decoder
     carbon-virtuals-decoder
     carbon-wavebreak-decoder
@@ -95,7 +93,7 @@ workspace_crates=(
 
 for crate in "${workspace_crates[@]}"; do
     echo "--- Yanking $crate version $VERSION"
-    cargo yank --version $VERSION $crate
+    cargo yank --version "$VERSION" "$crate"
 done
 
-echo "All crates yanked for version $VERSION" 
+echo "All crates yanked for version $VERSION"


### PR DESCRIPTION
## Summary

- prepare the 81 supported Rust crates for Carbon 2.0.0 with explicit per-crate versions and the workspace Rust 1.96.1 requirement
- update the TypeScript packages to 0.13.0 and generated projects for Carbon 2, Agave 4, and Transaction V1
- fix CLI package entry points, generated RPC configuration, and renderer CJS template resolution
- add the v2 migration notes and refresh the supported datasource/version documentation
- keep Jetstreamer and Jito Shredstream on their existing Carbon 1.x line

## Validation

- Rust formatting, clippy, tests, and Transaction V1 coverage passed on the implementation PR
- all 81 publishable crate manifests and package contents were checked
- pnpm frozen install, build, tests, type-check, and formatting passed
- generated RPC block-subscribe project compiled against the local Carbon 2 workspace
- release scripts pass shell syntax validation
